### PR TITLE
Feature/14 adapt request event notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .venv
 *~
+.vscode
+MODAK/log/
+__pycache__

--- a/MODAK/src/jobfile_generator.py
+++ b/MODAK/src/jobfile_generator.py
@@ -3,6 +3,75 @@ import os
 from tuner import tuner
 import logging
 
+"""Constant to represent the scheduler to use is SLURM"""
+SCHEDULER_SLURM="slurm"
+"""Constant to represent the scheduler to use is PBS Torque"""
+SCHEDULER_TORQUE="torque"
+
+class ArgumentConverter():
+        # Define which options are vaild of each of the schedulers
+    VAILD_TORQUE=['', 'a','b','e'] # abort, begin, end
+    VALID_SLURM=["", "NONE", "BEGIN", "END", "FAIL", "REQUEUE", "ALL",
+        "INVALID_DEPEND", "STAGE_OUT", "TIME_LIMIT", "TIME_LIMIT_90", 
+        "TIME_LIMIT_80", "TIME_LIMIT_50", "ARRAY_TASKS"]
+    SLURM_TO_TORQUE={
+        "NONE": "",
+        "BEGIN": "b", 
+        "END": "e", 
+        "FAIL": "a",
+        "REQUEUE": "",
+        "ALL": "abe",
+        "INVALID_DEPEND": "a",
+        "STAGE_OUT": "",
+        "TIME_LIMIT": "a",
+        "TIME_LIMIT_90": "", 
+        "TIME_LIMIT_80": "",
+        "TIME_LIMIT_50": "",
+        "ARRAY_TASKS": ""
+    }
+    TORQUE_TO_SLURM={
+        "a": "FAIL,INVALID_DEPEND,TIME_LIMIT",
+        "b": "BEGIN",
+        "e": "END"
+    }
+
+    def _slurm_to_torque(self, options):
+        # For each option in the slurm options, look it up in the 
+        # SLURM_TO_TORQUE dict. Then concatenate all the returned values
+        return "".join([self.SLURM_TO_TORQUE[opt] for opt in options.split(",")])
+
+    def _torque_to_slurm(self, options):
+        # For each character in the torque options, look it up in the
+        # TORQUE_TO_SLURM dict. Then concatenate all the returned vaules,
+        # separating them with commas 
+        return ",".join([self.TORQUE_TO_SLURM[opt] for opt in options])
+
+    def _is_slurm_options(self, options):
+        # Split the options string on commas, then check each part is a valid
+        # option. Return true if all are; false otherwise.
+        return all(opt in self.VALID_SLURM for opt in options.split(","))
+    
+    def _is_torque_options(self, options):
+        # For each character in the options, check if it is a valid torque
+        # option. If all are, return true, otherwise, false
+        return all(opt in self.VAILD_TORQUE for opt in options)
+
+    def convert_notifications(self, scheduler, notifications):    
+        # Check if the options we have match the scheduler we have
+        if scheduler==SCHEDULER_SLURM and self._is_torque_options(notifications) and notifications!="":
+            # Scheduler is slurm, but notifications are torque.
+            # convert then return
+            return self._torque_to_slurm(notifications)
+        elif scheduler==SCHEDULER_TORQUE and self._is_slurm_options(notifications) and notifications!="":
+            # Scheduler is torque, notifications are slurm.
+            # convert, then return
+            return self._slurm_to_torque(notifications)
+        # Scheduler and options match; return the original notification options
+        # (Also, if notifications are invalid this leaves them intact/unmodified)
+        return notifications
+
+
+
 class jobfile_generator():
     def __init__(self, job_json_obj, batch_file:str, scheduler:str = None):
         """Generates the job files, e.g. PBS and SLURM."""
@@ -14,14 +83,15 @@ class jobfile_generator():
         self.opt_data = job_json_obj.get('job').get('optimisation', {})
         self.singularity_exec = 'singularity exec'
         self.current_dir = './'
+        self.ac = ArgumentConverter()
         # TODO: scheduler type should be derived based on the infrastructure target name
         # TODO: there shall be an entry in the database where scheduler type is specified in the infrastructure target
         self.scheduler = scheduler if scheduler else self.job_json_obj.get("job", {}).get("target", {}).get("job_scheduler_type")
         self.target_name = self.job_json_obj.get("job", {}).get("target", {}).get("name")
         if self.target_name == "egi":
-            self.scheduler = "slurm"
+            self.scheduler = SCHEDULER_SLURM
         elif self.target_name == "hlrs_testbed":
-            self.scheduler = "torque"
+            self.scheduler = SCHEDULER_TORQUE    
 
     # Based on https://kb.northwestern.edu/page.php?id=89454
 
@@ -96,7 +166,8 @@ class jobfile_generator():
             f.write(DIRECTIVE + ' -W ' + self.job_data['job_dependency'])
             f.write('\n')
         if "request_event_notification" in self.job_data:
-            f.write(DIRECTIVE + ' -m ' + self.job_data['request_event_notification'])
+            f.write(DIRECTIVE + ' -m ' + 
+                self.ac.convert_notifications(SCHEDULER_TORQUE, self.job_data['request_event_notification']))
             f.write('\n')
         if "email_address" in self.job_data:
             f.write(DIRECTIVE + ' -M ' + self.job_data['email_address'])
@@ -187,7 +258,8 @@ class jobfile_generator():
             f.write(DIRECTIVE + ' --dependency=' + self.job_data['job_dependency'])
             f.write('\n')
         if "request_event_notification" in self.job_data:
-            f.write(DIRECTIVE + ' --mail-type=' + self.job_data['request_event_notification'])
+            f.write(DIRECTIVE + ' --mail-type=' + 
+                self.ac.convert_notifications(SCHEDULER_SLURM, self.job_data['request_event_notification']))
             f.write('\n')
         if "email_address" in self.job_data:
             f.write(DIRECTIVE + ' --mail-user=' + self.job_data['email_address'])
@@ -322,8 +394,8 @@ def main():
     dsl_file = "../test/input/tf_snow.json"
     with open(dsl_file) as json_file:
         obj = json.load(json_file)
-        gen_t = jobfile_generator(obj, "../test/torque.pbs","torque")
-        gen_s = jobfile_generator(obj, "../test/slurm.batch", "slurm")
+        gen_t = jobfile_generator(obj, "../test/torque.pbs", SCHEDULER_TORQUE)
+        gen_s = jobfile_generator(obj, "../test/slurm.batch", SCHEDULER_SLURM)
         gen_t.add_apprun()
         gen_s.add_apprun()
 

--- a/MODAK/test/test_jobfile_generator.py
+++ b/MODAK/test/test_jobfile_generator.py
@@ -1,0 +1,118 @@
+import unittest
+import jobfile_generator
+import json
+
+class test_ArgumentConverter(unittest.TestCase):
+    def setUp(self):
+        self.jfg = jobfile_generator.ArgumentConverter()
+
+    def test_is_slurm_options_valid_options(self):
+        self.assertTrue(self.jfg._is_slurm_options("BEGIN,TIME_LIMIT_90,FAIL,END"))
+        self.assertTrue(self.jfg._is_slurm_options("BEGIN"))
+        self.assertTrue(self.jfg._is_slurm_options(""))
+    
+    def test_is_torque_options_vaild_options(self):
+        self.assertTrue(self.jfg._is_torque_options("abe"))
+        self.assertTrue(self.jfg._is_torque_options("e"))
+        self.assertTrue(self.jfg._is_torque_options(""))
+
+    def test_is_slurm_options_torque(self):
+        self.assertFalse(self.jfg._is_slurm_options("abe"))
+    
+    def test_is_torque_options_slurm(self):
+        self.assertFalse(self.jfg._is_torque_options("BEGIN"))
+    
+    def test_is_slurm_options_invalid(self):
+        self.assertFalse(self.jfg._is_slurm_options("INVALIDOPT"))
+    
+    def test_is_torque_options_invalid(self):
+        self.assertFalse(self.jfg._is_torque_options("inv"))
+    
+    def test_slurm_to_torque_valid(self):
+        self.assertEqual(
+            self.jfg._slurm_to_torque("REQUEUE,BEGIN,END,FAIL,TIME_LIMIT"),
+            "beaa"
+        )
+        self.assertEqual(
+            self.jfg._slurm_to_torque("ALL"),
+            "abe"
+        )
+    
+    def test_torque_to_slurm_valid(self):
+        self.assertEqual(
+            self.jfg._torque_to_slurm("abe"),
+            "FAIL,INVALID_DEPEND,TIME_LIMIT,BEGIN,END"
+        )
+    
+    def test_convert_notifications_slurm_no_change(self):
+        TEST_STRING="ALL,TIME_LIMIT_50"
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_SLURM,
+                TEST_STRING),
+            TEST_STRING
+        )
+    
+    def test_convert_notifications_torque_no_change(self):
+        TEST_STRING="abe"
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_TORQUE,
+                TEST_STRING),
+            TEST_STRING
+        )
+    
+    def test_convert_notifications_slurm_to_torque(self):
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_TORQUE,
+                "END,BEGIN,FAIL,INVALID_DEPEND,REQUEUE"
+            ),
+            "ebaa"
+        )
+    
+    def test_convert_notifications_torque_to_slurm(self):
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_SLURM,
+                "abe"
+            ),
+            "FAIL,INVALID_DEPEND,TIME_LIMIT,BEGIN,END"
+        )
+    
+    def test_convert_notifications_torque_bad_opts(self):
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_TORQUE,
+                "abef"
+            ),
+            "abef"
+        )
+    
+    def test_convert_notifications_slurm_bad_opts(self):
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_SLURM,
+                "ALL,INVALID_OPT"
+            ),
+            "ALL,INVALID_OPT"
+        )
+    
+    def test_convert_notifications_blank(self):
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_SLURM,
+                ""
+            ),
+            ""
+        )
+        self.assertEqual(
+            self.jfg.convert_notifications(
+                jobfile_generator.SCHEDULER_TORQUE,
+                ""
+            ),
+            ""
+        )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/MODAK/test/test_jobfile_generator.py
+++ b/MODAK/test/test_jobfile_generator.py
@@ -9,12 +9,13 @@ class test_ArgumentConverter(unittest.TestCase):
     def test_is_slurm_options_valid_options(self):
         self.assertTrue(self.jfg._is_slurm_options("BEGIN,TIME_LIMIT_90,FAIL,END"))
         self.assertTrue(self.jfg._is_slurm_options("BEGIN"))
-        self.assertTrue(self.jfg._is_slurm_options(""))
+        self.assertTrue(self.jfg._is_slurm_options("NONE"))
     
     def test_is_torque_options_vaild_options(self):
         self.assertTrue(self.jfg._is_torque_options("abe"))
         self.assertTrue(self.jfg._is_torque_options("e"))
-        self.assertTrue(self.jfg._is_torque_options(""))
+        self.assertTrue(self.jfg._is_torque_options("p"))
+        self.assertTrue(self.jfg._is_torque_options("f"))
 
     def test_is_slurm_options_torque(self):
         self.assertFalse(self.jfg._is_slurm_options("abe"))
@@ -24,24 +25,39 @@ class test_ArgumentConverter(unittest.TestCase):
     
     def test_is_slurm_options_invalid(self):
         self.assertFalse(self.jfg._is_slurm_options("INVALIDOPT"))
+        self.assertFalse(self.jfg._is_slurm_options("NONE,ALL"))
     
     def test_is_torque_options_invalid(self):
         self.assertFalse(self.jfg._is_torque_options("inv"))
+        self.assertFalse(self.jfg._is_torque_options("na"))
+        self.assertFalse(self.jfg._is_torque_options("pa"))
     
     def test_slurm_to_torque_valid(self):
         self.assertEqual(
             self.jfg._slurm_to_torque("REQUEUE,BEGIN,END,FAIL,TIME_LIMIT"),
-            "beaa"
+            "befa"
         )
         self.assertEqual(
             self.jfg._slurm_to_torque("ALL"),
-            "abe"
+            "abef"
+        )
+        self.assertEqual(
+            self.jfg._slurm_to_torque("NONE"),
+            "n"
         )
     
     def test_torque_to_slurm_valid(self):
         self.assertEqual(
             self.jfg._torque_to_slurm("abe"),
             "FAIL,INVALID_DEPEND,TIME_LIMIT,BEGIN,END"
+        )
+        self.assertEqual(
+            self.jfg._torque_to_slurm("n"),
+            "FAIL"
+        )
+        self.assertEqual(
+            self.jfg._torque_to_slurm("p"),
+            "NONE"
         )
     
     def test_convert_notifications_slurm_no_change(self):
@@ -68,7 +84,7 @@ class test_ArgumentConverter(unittest.TestCase):
                 jobfile_generator.SCHEDULER_TORQUE,
                 "END,BEGIN,FAIL,INVALID_DEPEND,REQUEUE"
             ),
-            "ebaa"
+            "ebfa"
         )
     
     def test_convert_notifications_torque_to_slurm(self):
@@ -95,7 +111,7 @@ class test_ArgumentConverter(unittest.TestCase):
                 jobfile_generator.SCHEDULER_SLURM,
                 "ALL,INVALID_OPT"
             ),
-            "ALL,INVALID_OPT"
+            "ALL" #default
         )
     
     def test_convert_notifications_blank(self):
@@ -104,14 +120,14 @@ class test_ArgumentConverter(unittest.TestCase):
                 jobfile_generator.SCHEDULER_SLURM,
                 ""
             ),
-            ""
+            "ALL"
         )
         self.assertEqual(
             self.jfg.convert_notifications(
                 jobfile_generator.SCHEDULER_TORQUE,
                 ""
             ),
-            ""
+            "abe"
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves issue #14 by adding a class that allows bidirectional conversion between SLURM- and Torque-style notification settings. This also adds constants SCHEDULER_SLURM and SCHEDULER_TORQUE which are exported and can be used to represent the schedulers instead of passing around strings.

Testing:
The tests for this are in tests/test_jobfile_generator.py. These verify:

- That the conversion between the two formats works
- That no conversion occurs if an option is unrecognized
- That no conversion occurs when no arguments are passed
- That no conversion occurs when the format already matches the scheduler in use

Tests must be run inside the docker container.