### PR TITLE
Increase docker-compose resiliance to prior failures and other bad initial state.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,9 +110,9 @@ pipeline {
                 set -x
                 cd MODAK/
 
-                docker network prune || :
+                docker network prune -f || :
                 docker-compose down -v || :
-                docker network prune || :
+                docker network prune -f || :
                 if [ -n "\$(docker ps | grep modak)" ]; then
                     docker kill \$(docker ps | grep modak | awk '{print \$1}') || :
                 fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,9 @@ pipeline {
                 set -x
                 cd MODAK/
 
+                docker network prune || :
                 docker-compose down -v || :
+                docker network prune || :
                 if [ -n "\$(docker ps | grep modak)" ]; then
                     docker kill \$(docker ps | grep modak | awk '{print \$1}') || :
                 fi


### PR DESCRIPTION
This PR adds some additional commands to clean up docker state before trying to set up the docker-compose environment for running tests.

Resolves #38 .