### PR TITLE
DB model refactoring and generic script generator, including CLI and web API for infra & script insert

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,7 +113,7 @@ pipeline {
                 docker rm modak-unittest || :
 
                 docker build -t modak-unittest .
-                docker run --name modak-unittest modak-unittest pytest --junitxml="modak-results-docker.xml" --cov=src
+                docker run --name modak-unittest modak-unittest pytest --junitxml="modak-results-docker.xml" --cov=MODAK
                 docker cp modak-unittest:/opt/app/modak-results-docker.xml ..
                 docker rm modak-unittest
                 '''

--- a/MODAK/MODAK/MODAK.py
+++ b/MODAK/MODAK/MODAK.py
@@ -1,5 +1,4 @@
 import logging
-import pathlib
 from copy import deepcopy
 from datetime import datetime
 from typing import NamedTuple, cast
@@ -11,20 +10,16 @@ from .jobfile_generator import JobfileGenerator
 from .mapper import Mapper
 from .MODAK_driver import MODAK_driver
 from .model import ApplicationBuild, Job
-from .settings import DEFAULT_SETTINGS_DIR, Settings
+from .settings import Settings
 
 JobScripts = NamedTuple("JobScripts", [("jobscript", str), ("buildscript", str)])
 
 
 class MODAK:
-    def __init__(
-        self,
-        conf_file: pathlib.Path = DEFAULT_SETTINGS_DIR / "iac-model.ini",
-        upload=False,
-    ):
+    def __init__(self, upload=False):
         """General MODAK class."""
         logging.info("Intialising MODAK")
-        self._driver = MODAK_driver(conf_file)
+        self._driver = MODAK_driver()
         self._map = Mapper(self._driver)
         self._enf = Enforcer(self._driver)
         self._job_link = ""
@@ -49,7 +44,7 @@ class MODAK:
 
         logging.info("Generating job file header")
         job_file = (
-            Settings.OUT_DIR
+            Settings.out_dir
             / f"{job.job_options.job_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}.sh"
         )
         gen_t = JobfileGenerator(
@@ -65,7 +60,7 @@ class MODAK:
         logging.info("Generating build file")
         buildjob = self.get_buildjob(job)
         build_file = (
-            Settings.OUT_DIR
+            Settings.out_dir
             / f"{job.job_options.job_name}_build_{datetime.now().strftime('%Y%m%d%H%M%S')}"
         )
 
@@ -163,7 +158,7 @@ class MODAK:
 
         logging.info("Generating job file header")
         job_file = (
-            Settings.OUT_DIR
+            Settings.out_dir
             / f"{job.job_options.job_name}_{datetime.now().strftime('%Y%m%d%H%M%S')}.sh"
         )
         gen_t = JobfileGenerator(

--- a/MODAK/MODAK/MODAK.py
+++ b/MODAK/MODAK/MODAK.py
@@ -72,8 +72,11 @@ class MODAK:
             gen_t.add_tuner(job.optimisation, upload=self._upload)
 
         logging.info(f"Applying optimisations {self._map.get_opts()}")
-        for opt in self._enf.enforce_opt(self._map.get_opts()):
-            gen_t.add_optscript(opt.script_name, opt.script_loc)
+        assert job.target, "Target must be defined"
+        for script in self._enf.enforce_opt(
+            self._map.app_name, job.target, self._map.get_opts()
+        ):
+            gen_t.add_optscript(script)
 
         logging.info("Adding application run")
         gen_t.add_apprun()
@@ -175,10 +178,14 @@ class MODAK:
             logging.info("Adding autotuning scripts")
             gen_t.add_tuner(self._upload)
 
-        decoded_opts = self._map.get_decoded_opts(job.optimisation, job.target)
+        decoded_opts = self._map.get_decoded_opts(job.optimisation)
         logging.info(f"Applying optimisations {decoded_opts}")
-        for opt in self._enf.enforce_opt(decoded_opts):
-            gen_t.add_optscript(opt.script_name, opt.script_loc)
+
+        assert job.target, "Target must be defined"
+        for script in self._enf.enforce_opt(
+            self._map.app_name, job.target, decoded_opts
+        ):
+            gen_t.add_optscript(script)
 
         logging.info("Adding application run")
         gen_t.add_apprun()

--- a/MODAK/MODAK/MODAK.py
+++ b/MODAK/MODAK/MODAK.py
@@ -56,7 +56,7 @@ class MODAK:
             job.application,
             job.job_options,
             batch_file=job_file,
-            scheduler=job.target.job_scheduler_type if job.target else "",
+            scheduler=str(job.target.job_scheduler_type) if job.target else "",
         )
 
         logging.info("Adding job header")
@@ -170,7 +170,7 @@ class MODAK:
             job.application,
             job.job_options,
             batch_file=job_file,
-            scheduler=job.target.job_scheduler_type if job.target else "",
+            scheduler=str(job.target.job_scheduler_type) if job.target else "",
         )
 
         logging.info("Adding job header")

--- a/MODAK/MODAK/MODAK.py
+++ b/MODAK/MODAK/MODAK.py
@@ -77,10 +77,8 @@ class MODAK:
             gen_t.add_tuner(job.optimisation, upload=self._upload)
 
         logging.info(f"Applying optimisations {self._map.get_opts()}")
-        opts = self._enf.enforce_opt(self._map.get_opts())
-        for opt in opts:
-            for idx in range(0, opt.shape[0]):
-                gen_t.add_optscript(opt["script_name"][idx], opt["script_loc"][idx])
+        for opt in self._enf.enforce_opt(self._map.get_opts()):
+            gen_t.add_optscript(opt.script_name, opt.script_loc)
 
         logging.info("Adding application run")
         gen_t.add_apprun()
@@ -184,10 +182,8 @@ class MODAK:
 
         decoded_opts = self._map.get_decoded_opts(job.optimisation, job.target)
         logging.info(f"Applying optimisations {decoded_opts}")
-        opts = self._enf.enforce_opt(decoded_opts)
-        for opt in opts:
-            for i in range(0, opt.shape[0]):
-                gen_t.add_optscript(opt["script_name"][i], opt["script_loc"][i])
+        for opt in self._enf.enforce_opt(decoded_opts):
+            gen_t.add_optscript(opt.script_name, opt.script_loc)
 
         logging.info("Adding application run")
         gen_t.add_apprun()

--- a/MODAK/MODAK/MODAK_driver.py
+++ b/MODAK/MODAK/MODAK_driver.py
@@ -1,7 +1,8 @@
 import logging
-import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Tuple
+
+import sqlalchemy as sa
 
 # from MODAK_sql import MODAK_sql
 from .settings import DEFAULT_SETTINGS_DIR, Settings
@@ -26,102 +27,21 @@ class MODAK_driver:
         Settings.initialise(conf_file)
 
         logging.info("Connecting to model repo using DB dialect: {Settings.DB_DIALECT}")
+        assert Settings.DB_DIALECT == "sqlite", "only SQLite is currently supported"
 
-        if Settings.DB_DIALECT == "mysql":
-            import mysql.connector
-
-            try:
-                self.cnx = mysql.connector.connect(
-                    user=Settings.DB_USER,
-                    password=Settings.DB_PASSWORD,
-                    host=Settings.DB_HOST,
-                    port=Settings.DB_PORT,
-                    database=Settings.DB_NAME,
-                )
-            except mysql.connector.Error:
-                logging.exception(
-                    f"Error connecting to MODAK repository DB '{Settings.DB_NAME}'"
-                    f" on '{Settings.DB_HOST}' with user '{Settings.DB_USER}'"
-                )
-                raise
-
-        elif Settings.DB_DIALECT == "sqlite":
-            import sqlite3
-
-            try:
-                self.cnx = sqlite3.connect(Settings.DB_PATH)
-            except Exception:
-                logging.exception(
-                    f"Error connecting to MODAK repository DB '{Settings.DB_PATH}'"
-                )
-                raise
-
-        # self.__init_IaC_modelrepo(install)
-        if Settings.QUIET_SERVER_LOGS:
-            self._quiet_logs()
-
+        self._engine = sa.create_engine(f"sqlite:///{Settings.DB_PATH}")
         logging.info("Successfully initialised driver")
 
-    def __del__(self):
-        try:
-            self.cnx.close()
-        except AttributeError:
-            pass
-
-    def selectSQL(
-        self, sqlstr: str, query_params: Optional[Union[Tuple, Dict[str, Any]]] = None
-    ) -> List[Tuple[Any, ...]]:
-        sqlstr = re.sub(r"\s{2,}", " ", sqlstr.replace("\n", " "))
-
-        if Settings.DB_DIALECT == "sqlite":
-            sqlstr = re.sub(r"%\((?P<key>[^\)]+)\)s", r":\g<key>", sqlstr)
-            sqlstr = sqlstr.replace("%s", "?")
-
-        if not sqlstr:
-            logging.error("Empty or invalid sql string")
-            raise ValueError("Empty or invalid SQL statement")
-
-        logging.info(f"Selecting : {sqlstr}")
-        try:
-            if query_params:
-                cursor = self.cnx.execute(sqlstr, query_params)
-            else:
-                cursor = self.cnx.execute(sqlstr)
-
+    def selectSQL(self, stmt: str) -> List[Tuple[Any, ...]]:
+        logging.info(f"Selecting : {stmt}")
+        with sa.orm.Session(self._engine, future=True) as session:
+            result = session.execute(stmt).all()
             logging.info("Successfully selected SQL")
-        except Exception:
-            logging.exception("Error executing SQL")
-            raise
 
-        return cursor.fetchall()
+        return result
 
-    def updateSQL(
-        self, sqlstr, query_params: Optional[Union[Tuple, Dict[str, Any]]] = None
-    ):
-        sqlstr = re.sub(r"\s{2,}", " ", sqlstr.replace("\n", " "))
-
-        if Settings.DB_DIALECT == "sqlite":
-            sqlstr = re.sub(r"%\((?P<key>[^\)]+)\)s", r":\g<key>", sqlstr)
-            sqlstr = sqlstr.replace("%s", "?")
-
-        if not sqlstr:
-            logging.error("Empty or invalid sql string")
-            raise ValueError("Empty or invalid SQL statement")
-
-        try:
-            logging.info(f"Updating : {sqlstr}")
-            cur = self.cnx.cursor()
-            cur.execute(sqlstr, query_params)
-            # # Put it all to a data frame
-            self.cnx.commit()
+    def updateSQL(self, stmt: str):
+        with sa.orm.Session(self._engine, future=True) as session:
+            session.execute(stmt)
+            session.commit()
             logging.info("Successfully updated SQL")
-            return True
-        except AttributeError:
-            logging.warning("No connected database")
-            return False
-        except Exception:
-            logging.exception("Error connecting to modak repo")
-            raise
-
-    def _quiet_logs(self):
-        pass

--- a/MODAK/MODAK/MODAK_driver.py
+++ b/MODAK/MODAK/MODAK_driver.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 
 import sqlalchemy as sa
 
@@ -28,10 +28,10 @@ class MODAK_driver:
         logging.info("Connecting to model repo using DB dialect: {Settings.db_dialect}")
         assert Settings.db_dialect == "sqlite", "only SQLite is currently supported"
 
-        self._engine = sa.create_engine(f"sqlite:///{Settings.db_path}")
+        self._engine = sa.create_engine(f"sqlite:///{Settings.db_path}", echo=True)
         logging.info("Successfully initialised driver")
 
-    def selectSQL(self, stmt: str) -> List[Tuple[Any, ...]]:
+    def selectSQL(self, stmt: sa.sql.Select) -> List[Tuple[Any, ...]]:
         logging.info(f"Selecting : {stmt}")
         with sa.orm.Session(self._engine, future=True) as session:
             result = session.execute(stmt).all()
@@ -39,7 +39,7 @@ class MODAK_driver:
 
         return result
 
-    def updateSQL(self, stmt: str):
+    def updateSQL(self, stmt: Union[sa.sql.Delete, sa.sql.Update]):
         with sa.orm.Session(self._engine, future=True) as session:
             session.execute(stmt)
             session.commit()

--- a/MODAK/MODAK/MODAK_driver.py
+++ b/MODAK/MODAK/MODAK_driver.py
@@ -22,14 +22,13 @@ class MODAK_driver:
     )
     logging.getLogger("py4j").setLevel(logging.ERROR)
 
-    def __init__(self, conf_file=DEFAULT_SETTINGS_DIR / "iac-model.ini", install=False):
+    def __init__(self):
         logging.info("Initialising driver")
-        Settings.initialise(conf_file)
 
-        logging.info("Connecting to model repo using DB dialect: {Settings.DB_DIALECT}")
-        assert Settings.DB_DIALECT == "sqlite", "only SQLite is currently supported"
+        logging.info("Connecting to model repo using DB dialect: {Settings.db_dialect}")
+        assert Settings.db_dialect == "sqlite", "only SQLite is currently supported"
 
-        self._engine = sa.create_engine(f"sqlite:///{Settings.DB_PATH}")
+        self._engine = sa.create_engine(f"sqlite:///{Settings.db_path}")
         logging.info("Successfully initialised driver")
 
     def selectSQL(self, stmt: str) -> List[Tuple[Any, ...]]:

--- a/MODAK/MODAK/MODAK_dropbox.py
+++ b/MODAK/MODAK/MODAK_dropbox.py
@@ -5,14 +5,12 @@ from datetime import datetime
 import dropbox
 from dropbox import DropboxOAuth2FlowNoRedirect
 
+from .settings import Settings
+
 
 class TransferData:
-    def __init__(self, access_token=""):
-        if access_token == "":
-            self.access_token = (
-                access_token
-            ) = "uIdLbZ5c1OAAAAAAAAAAbyk8y7dUYKwD4BlLXa7m7lOosadXk1GAZPyr760SCrr-"
-        self.access_token = access_token
+    def __init__(self):
+        self.access_token = Settings.dropbox_access_token
         self.dbx = dropbox.Dropbox(self.access_token)
 
     def login_dropbox(self):

--- a/MODAK/MODAK/MODAK_gcloud.py
+++ b/MODAK/MODAK/MODAK_gcloud.py
@@ -3,14 +3,18 @@ import logging
 import google.cloud.exceptions
 from google.cloud import storage
 
+from .settings import Settings
+
 
 class TransferData:
-    def __init__(self, google_cred="../conf/modak-f305a35c96dc.json"):
+    def __init__(self):
         # Explicitly use service account credentials by specifying the private key
         # file.
         logging.info("Initialising gcloud storage")
         try:
-            self.storage_client = storage.Client.from_service_account_json(google_cred)
+            self.storage_client = storage.Client.from_service_account_json(
+                Settings.google_credentials
+            )
             self.bucket = self.storage_client.get_bucket("modak-bucket")
         except google.cloud.exceptions:
             logging.exception("Connecting to the Google cloud bucket failed")

--- a/MODAK/MODAK/app.py
+++ b/MODAK/MODAK/app.py
@@ -24,6 +24,8 @@ from MODAK.model import (
 )
 from MODAK.settings import Settings
 
+from . import modeldb
+
 BASE_PATH = pathlib.Path(__file__).resolve().parent
 app = FastAPI(title="MODAK Application Optimizer")
 templates = Jinja2Templates(directory=str(BASE_PATH / "templates"))
@@ -143,9 +145,8 @@ async def create_script(
 ):
     """Add a new script"""
 
-    dbobj = db.Script(**script_in.dict())
-
     async with session.begin():
+        dbobj = await modeldb.create_script(session, script_in)
         session.add(dbobj)
 
     return dbobj

--- a/MODAK/MODAK/app.py
+++ b/MODAK/MODAK/app.py
@@ -9,7 +9,7 @@ from MODAK.MODAK import MODAK
 from MODAK.model import JobModel
 
 BASE_PATH = pathlib.Path(__file__).resolve().parent
-app = FastAPI()
+app = FastAPI(title="MODAK Application Optimizer")
 templates = Jinja2Templates(directory=str(BASE_PATH / "templates"))
 
 

--- a/MODAK/MODAK/app.py
+++ b/MODAK/MODAK/app.py
@@ -131,7 +131,7 @@ async def get_script(
     try:
         return result.scalars().one()
     except NoResultFound:
-        raise HTTPException(404)
+        raise HTTPException(404) from None
 
 
 @app.post(
@@ -182,7 +182,7 @@ async def get_infrastructure(
     try:
         return result.scalars().one()
     except NoResultFound:
-        raise HTTPException(404)
+        raise HTTPException(404) from None
 
 
 @app.post(

--- a/MODAK/MODAK/app.py
+++ b/MODAK/MODAK/app.py
@@ -1,16 +1,43 @@
 #!/usr/bin/env python3
 
 import pathlib
+from typing import List
+from uuid import UUID
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.exc import NoResultFound
 
+from MODAK.db import Script as ScriptDB
 from MODAK.MODAK import MODAK
-from MODAK.model import JobModel
+from MODAK.model import JobModel, Script, ScriptIn, ScriptList
+from MODAK.settings import Settings
 
 BASE_PATH = pathlib.Path(__file__).resolve().parent
 app = FastAPI(title="MODAK Application Optimizer")
 templates = Jinja2Templates(directory=str(BASE_PATH / "templates"))
+
+engine = create_async_engine(f"sqlite+aiosqlite:///{Settings.db_path}", future=True)
+SessionLocal = sessionmaker(
+    engine,
+    class_=AsyncSession,
+    autocommit=False,
+    autoflush=False,
+    expire_on_commit=False,
+)
+
+
+async def get_db_session() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    await engine.dispose()
 
 
 @app.get("/")
@@ -67,9 +94,43 @@ async def get_build(model: JobModel):
 @app.post(
     "/get_optimisation", response_model=JobModel, response_model_exclude_none=True
 )
-def modak_get_optimisation(model: JobModel):
+async def modak_get_optimisation(model: JobModel):
     m = MODAK()
     model.job.application.container_runtime, model.job.job_content = m.get_optimisation(
         model.job
     )
     return model
+
+
+@app.get("/scripts", response_model=List[ScriptList])
+async def list_scripts(session: AsyncSession = Depends(get_db_session)):  # noqa: B008
+    """List all registered scripts"""
+    result = await session.execute(select(ScriptDB))
+    return result.scalars().all()
+
+
+@app.get("/scripts/{script_id}", response_model=Script)
+async def get_script(
+    script_id: UUID, session: AsyncSession = Depends(get_db_session)  # noqa: B008
+):
+    """Get script"""
+    result = await session.execute(select(ScriptDB).where(ScriptDB.id == script_id))
+
+    try:
+        return result.scalars().one()
+    except NoResultFound:
+        raise HTTPException(404)
+
+
+@app.post("/scripts", response_model=ScriptList, status_code=201)
+async def create_script(
+    script_in: ScriptIn, session: AsyncSession = Depends(get_db_session)  # noqa: B008
+):
+    """Add a new script"""
+
+    dbobj = ScriptDB(**script_in.dict())
+
+    async with session.begin():
+        session.add(dbobj)
+
+    return dbobj

--- a/MODAK/MODAK/cli.py
+++ b/MODAK/MODAK/cli.py
@@ -36,8 +36,19 @@ def validate_json():
         sys.exit(1)
 
 
-def openapi():
-    parser = argparse.ArgumentParser(description="Generate the OpenAPI schema")
+def schema():
+    parser = argparse.ArgumentParser(description="Generate different schema documents")
+    parser.add_argument(
+        "schema",
+        metavar="<SCHEMA>",
+        type=str,
+        choices=("openapi", "dsl"),
+        default="openapi",
+        help=(
+            "The schema to generate: 'openapi' for the complete web OpenAPI/Swagger schema,"
+            " 'dsl' for the JSON schema for the DSL"
+        ),
+    )
     parser.add_argument(
         "outfile",
         metavar="<FILE>",
@@ -53,20 +64,24 @@ def openapi():
         help="Do not pretty print the generated JSON.",
     )
     args = parser.parse_args()
-    openapi_schema = get_openapi(
-        title=app.title,
-        version=app.version,
-        openapi_version=app.openapi_version,
-        description=app.description,
-        routes=app.routes,
-    )
+
+    if args.schema == "openapi":
+        json_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            openapi_version=app.openapi_version,
+            description=app.description,
+            routes=app.routes,
+        )
+    elif args.schema == "dsl":
+        json_schema = JobModel.schema()
 
     dumpopts = {}
 
     if not args.raw:
         dumpopts["indent"] = 2
 
-    json.dump(openapi_schema, args.outfile, **dumpopts)
+    json.dump(json_schema, args.outfile, **dumpopts)
 
 
 def modak():

--- a/MODAK/MODAK/cli.py
+++ b/MODAK/MODAK/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import pathlib
 import sys
 from typing import Any, Dict
@@ -112,7 +113,22 @@ def modak():
         default=DEFAULT_SETTINGS_DIR / "iac-model.ini",
         help=f"Configuration file (default: {DEFAULT_SETTINGS_DIR / 'iac-model.ini'}",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Enable verbose logging output",
+        action="count",
+        dest="loglevel",
+        default=0,
+    )
     args = parser.parse_args()
+
+    loglevel = logging.WARNING
+    if args.loglevel >= 2:
+        loglevel = logging.DEBUG
+    elif args.loglevel > 1:
+        loglevel = logging.INFO
+    logging.basicConfig(level=loglevel, force=True)
 
     print(f"Input file: '{args.ifile.name}'", file=sys.stderr)
     print(f"Output file: '{args.ofile.name}'", file=sys.stderr)

--- a/MODAK/MODAK/cli.py
+++ b/MODAK/MODAK/cli.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import logging
-import pathlib
 import sys
 from typing import Any, Dict
 
@@ -14,7 +13,6 @@ from . import db
 from .app import app
 from .MODAK import MODAK
 from .model import JobModel
-from .settings import DEFAULT_SETTINGS_DIR
 
 
 def validate_json():
@@ -122,14 +120,6 @@ def modak():
         help="Output file (default: write to stdout)",
     )
     parser.add_argument(
-        "-c",
-        "--config",
-        metavar="CONFIGFILE",
-        type=pathlib.Path,
-        default=DEFAULT_SETTINGS_DIR / "iac-model.ini",
-        help=f"Configuration file (default: {DEFAULT_SETTINGS_DIR / 'iac-model.ini'}",
-    )
-    parser.add_argument(
         "-v",
         "--verbose",
         help="Enable verbose logging output",
@@ -149,7 +139,7 @@ def modak():
     print(f"Input file: '{args.ifile.name}'", file=sys.stderr)
     print(f"Output file: '{args.ofile.name}'", file=sys.stderr)
 
-    m = MODAK(args.config)
+    m = MODAK()
 
     model = JobModel.parse_raw(args.ifile.read())
 

--- a/MODAK/MODAK/cli.py
+++ b/MODAK/MODAK/cli.py
@@ -108,7 +108,7 @@ def schema():
     elif args.schema == "sql":
         for tbl in db.__all__:
             print(
-                CreateTable(getattr(getattr(db, tbl), "__table__")).compile(
+                CreateTable(getattr(db, tbl).__table__).compile(
                     dialect=sqlite.dialect()
                 ),
                 file=args.outfile,

--- a/MODAK/MODAK/db.py
+++ b/MODAK/MODAK/db.py
@@ -1,4 +1,4 @@
-__all__ = ["Optimisation", "Map", "OptScript", "Infrastructure", "Script"]
+__all__ = ["Optimisation", "Map", "Infrastructure", "Script"]
 
 import uuid
 
@@ -75,19 +75,10 @@ class Map(Base):
     src = Column(String(255), nullable=True, default=None)
 
 
-class OptScript(Base):
-    __tablename__ = "optscript"
-
-    opt_code = Column(String(255), primary_key=True)
-    script_name = Column(String(255), nullable=False)
-    script_loc = Column(String(5000), nullable=True)
-    stage = Column(Integer, nullable=True)
-
-
 class Infrastructure(Base):
     __tablename__ = "infrastructure"
 
-    id = Column(GUID, primary_key=True)
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
     name = Column(String(255), primary_key=True, unique=True)  # for now unique
     disabled = Column(
         DateTime, nullable=True

--- a/MODAK/MODAK/db.py
+++ b/MODAK/MODAK/db.py
@@ -1,8 +1,51 @@
-__all__ = ["Optimisation", "Map", "OptScript"]
+__all__ = ["Optimisation", "Map", "OptScript", "Infrastructure", "Script"]
 
-from sqlalchemy import Column, ForeignKey, Integer, String, event
+import uuid
+
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, String, Text, event
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeMeta, declarative_base
+from sqlalchemy.types import CHAR, TypeDecorator
+
+
+class GUID(TypeDecorator):
+    """Platform-independent GUID type.
+
+    Uses PostgreSQL's UUID type, otherwise uses
+    CHAR(32), storing as stringified hex values.
+
+    """
+
+    impl = CHAR
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(UUID())
+        else:
+            return dialect.type_descriptor(CHAR(32))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        elif dialect.name == "postgresql":
+            return str(value)
+        else:
+            if not isinstance(value, uuid.UUID):
+                return "%.32x" % uuid.UUID(value).int
+            else:
+                # hexstring
+                return "%.32x" % value.int
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        else:
+            if not isinstance(value, uuid.UUID):
+                value = uuid.UUID(value)
+            return value
+
 
 Base: DeclarativeMeta = declarative_base()
 
@@ -39,6 +82,85 @@ class OptScript(Base):
     script_name = Column(String(255), nullable=False)
     script_loc = Column(String(5000), nullable=True)
     stage = Column(Integer, nullable=True)
+
+
+class Infrastructure(Base):
+    __tablename__ = "infrastructure"
+
+    id = Column(GUID, primary_key=True)
+    name = Column(String(255), primary_key=True, unique=True)  # for now unique
+    disabled = Column(
+        DateTime, nullable=True
+    )  # use a timestamp to get more information on when it was disabled
+    description = Column(Text, nullable=True)
+    configuration = Column(JSON, nullable=False, server_default="{}")
+
+
+class Script(Base):
+    """Infrastructure- or code-specific environment setup and teardown scripts.
+
+    An infrastructures or a code may need additional settings (environment variables,
+    modules loaded, etc.) to run specific workloads. We allow for schema-less conditions
+    (which will be tied to an infrastructures configuration or code-specific features
+    and will be evaluated against the requested/required capabilities of a workload) and
+    store them in another schema-less column.
+
+    Examples for conditions (in YAML):
+
+    1) to always include this when running on the hlrs_testbed infrastructure
+
+        infrastructure:
+            name: hlrs_testbed
+
+    2) to always include this when running on the specified infras GPU partition
+
+        infrastructure:
+            id: F1069039-492D-4A23-BFB1-03AECC593C64
+            partition: gpu
+
+    2) or alternatively, when requesting GPU acceleration on the same infrastructure
+
+        infrastructure:
+            id: F1069039-492D-4A23-BFB1-03AECC593C64
+            accelerator: gpu
+
+    3) to be included when running a tensorflow workflow with the XLA compiler enabled
+
+        application:
+            name: tensorflow
+            feature: xla
+
+    Examples for data (in YAML):
+
+    1) a string which will be inserted verbatim into the generated script right after
+       the generated headers
+
+        stage: pre
+        raw: "export FOO=bar\\\nmodule load baz"
+
+    2) the same input, but structured (which would allow to yield code for different
+       shells or module environments):
+
+        stage: pre
+        structure:
+        - env:
+            FOO: bar
+        - module:
+            load: baz
+
+    3) to include a script which has to be run by a different interpreter:
+
+        stage: pre
+        interpreter: #!/usr/bin/env python
+        raw: "print('hello, world!')"
+    """
+
+    __tablename__ = "script"
+
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
+    description = Column(Text, nullable=True)
+    conditions = Column(JSON, nullable=False, server_default="{}")
+    data = Column(JSON, nullable=False, server_default="{}")
 
 
 @event.listens_for(Engine, "connect")

--- a/MODAK/MODAK/db.py
+++ b/MODAK/MODAK/db.py
@@ -1,0 +1,50 @@
+__all__ = ["Optimisation", "Map", "OptScript"]
+
+from sqlalchemy import Column, ForeignKey, Integer, String, event
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import DeclarativeMeta, declarative_base
+
+Base: DeclarativeMeta = declarative_base()
+
+
+class Optimisation(Base):
+    __tablename__ = "optimisation"
+
+    opt_dsl_code = Column(String(255), primary_key=True)
+    app_name = Column(String(255), nullable=False)
+    target = Column(String(5000), nullable=True, default=None)
+    optimisation = Column(String(5000), nullable=True)
+    version = Column(String(255), nullable=True)
+
+
+class Map(Base):
+    __tablename__ = "mapper"
+
+    map_id = Column(Integer, primary_key=True)
+    opt_dsl_code = Column(
+        String(255),
+        ForeignKey("optimisation.opt_dsl_code", ondelete="CASCADE", onupdate="CASCADE"),
+        nullable=False,
+    )
+    container_file = Column(String(255), nullable=True, default=None)
+    image_type = Column(String(255), nullable=True, default=None)
+    image_hub = Column(String(255), nullable=True, default=None)
+    src = Column(String(255), nullable=True, default=None)
+
+
+class OptScript(Base):
+    __tablename__ = "optscript"
+
+    opt_code = Column(String(255), primary_key=True)
+    script_name = Column(String(255), nullable=False)
+    script_loc = Column(String(5000), nullable=True)
+    stage = Column(Integer, nullable=True)
+
+
+@event.listens_for(Engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    """Always enable foreign key support on SQLite
+    see https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#sqlite-foreign-keys"""
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()

--- a/MODAK/MODAK/enforcer.py
+++ b/MODAK/MODAK/enforcer.py
@@ -1,6 +1,10 @@
 import logging
+from collections import namedtuple
+from typing import List
 
 from .MODAK_driver import MODAK_driver
+
+EnforcerEntry = namedtuple("EnforcerEntry", ["script_name", "script_loc", "stage"])
 
 
 class Enforcer:
@@ -8,11 +12,11 @@ class Enforcer:
         logging.info("Initialised MODAK enforcer")
         self._driver = driver
 
-    def enforce_opt(self, opts):
+    def enforce_opt(self, opts: List[str]) -> List[EnforcerEntry]:
         logging.info(f"Enforcing opts {opts}")
         # TODO: do we enforce only one optimisation?
         # TODO: redo if it is the case
-        dfs = []
+        data = []
         for opt in opts:
             if "version" in opt:
                 logging.info("Ignore version as a optimisation")
@@ -21,10 +25,10 @@ class Enforcer:
             opt_key, opt_value = opt.split(":")
 
             if "true" in opt_value:
-                df = self._driver.applySQL(
+                oneopt_data = self._driver.selectSQL(
                     "SELECT script_name, script_loc, stage FROM optscript"
                     " WHERE opt_code = %s",
                     (opt_key,),
                 )
-                dfs.append(df)
-        return dfs
+                data += [EnforcerEntry(*e) for e in oneopt_data]
+        return data

--- a/MODAK/MODAK/enforcer.py
+++ b/MODAK/MODAK/enforcer.py
@@ -2,6 +2,9 @@ import logging
 from collections import namedtuple
 from typing import List
 
+from sqlalchemy import select
+
+from .db import OptScript
 from .MODAK_driver import MODAK_driver
 
 EnforcerEntry = namedtuple("EnforcerEntry", ["script_name", "script_loc", "stage"])
@@ -25,10 +28,9 @@ class Enforcer:
             opt_key, opt_value = opt.split(":")
 
             if "true" in opt_value:
-                oneopt_data = self._driver.selectSQL(
-                    "SELECT script_name, script_loc, stage FROM optscript"
-                    " WHERE opt_code = %s",
-                    (opt_key,),
-                )
+                stmt = select(
+                    OptScript.script_name, OptScript.script_loc, OptScript.stage
+                ).where(OptScript.opt_code == opt_key)
+                oneopt_data = self._driver.selectSQL(stmt)
                 data += [EnforcerEntry(*e) for e in oneopt_data]
         return data

--- a/MODAK/MODAK/enforcer.py
+++ b/MODAK/MODAK/enforcer.py
@@ -1,13 +1,11 @@
 import logging
-from collections import namedtuple
 from typing import List
 
-from sqlalchemy import select
+from sqlalchemy import JSON, select
 
-from .db import OptScript
+from . import db
 from .MODAK_driver import MODAK_driver
-
-EnforcerEntry = namedtuple("EnforcerEntry", ["script_name", "script_loc", "stage"])
+from .model import Script, Target
 
 
 class Enforcer:
@@ -15,22 +13,86 @@ class Enforcer:
         logging.info("Initialised MODAK enforcer")
         self._driver = driver
 
-    def enforce_opt(self, opts: List[str]) -> List[EnforcerEntry]:
+    def enforce_opt(
+        self, app_name: str, target: Target, opts: List[str]
+    ) -> List[Script]:
         logging.info(f"Enforcing opts {opts}")
         # TODO: do we enforce only one optimisation?
         # TODO: redo if it is the case
-        data = []
-        for opt in opts:
-            if "version" in opt:
-                logging.info("Ignore version as a optimisation")
-                continue
+        scripts = []
 
-            opt_key, opt_value = opt.split(":")
+        basestmt = select(db.Script).filter(
+            db.Script.conditions["application"]["name"].as_string() == app_name
+        )
+        basestmts = []
 
-            if "true" in opt_value:
-                stmt = select(
-                    OptScript.script_name, OptScript.script_loc, OptScript.stage
-                ).where(OptScript.opt_code == opt_key)
-                oneopt_data = self._driver.selectSQL(stmt)
-                data += [EnforcerEntry(*e) for e in oneopt_data]
-        return data
+        # TODO: at the moment the target name is optional
+        if target.name:
+            basestmts.append(
+                basestmt.filter(
+                    db.Script.conditions["infrastructure"]["name"].as_string()
+                    == target.name
+                )
+            )
+
+        basestmts.append(
+            basestmt.filter(db.Script.conditions["infrastructure"] == JSON.NULL)
+        )
+
+        # Logic:
+        #   1. Look for feature-conditional scripts for a given app
+        #      and infra (if infra is defined)
+        #   2. Look for feature-unconditional scripts for a given app
+        #      and infra (if infra is defined)
+        #   3. Repeat 1. & 2. without restriction for
+        #      non-infra-restricted scripts
+        for basestmt in basestmts:
+            # TODO: currently we do an OR for each option,
+            #       while we probably should be doing an AND
+            for opt in opts:
+                if "version" in opt:
+                    logging.info("Ignore version as a optimisation")
+                    continue
+
+                opt_key, opt_value = opt.split(":")
+
+                # "unparse" the options again to be able to use them to query
+                # directly the features in Script
+                if opt_value.lower() == "true":
+                    stmt = basestmt.filter(
+                        db.Script.conditions["application"]["feature"][
+                            opt_key
+                        ].as_boolean()
+                        == True  # noqa: E712
+                    )
+                elif opt_value.lower() == "false":
+                    stmt = basestmt.filter(
+                        db.Script.conditions["application"]["feature"][
+                            opt_key
+                        ].as_boolean()
+                        == False  # noqa: E712
+                    )
+                else:
+                    try:
+                        stmt = basestmt.filter(
+                            db.Script.conditions["application"]["feature"][
+                                opt_key
+                            ].as_integer()
+                            == int(opt_value)
+                        )
+                    except ValueError:
+                        stmt = basestmt.filter(
+                            db.Script.conditions["application"]["feature"][
+                                opt_key
+                            ].as_string()
+                            == opt_value
+                        )
+
+                scripts += self._driver.selectSQL(stmt)
+
+            # now run the stmt alone to grab all generic infra- or app-only scripts
+            scripts += self._driver.selectSQL(basestmt)
+
+        # remove duplicates while preserving order, use UUID as hashable key
+        # ... and convert to model
+        return list({o[0].id: Script.from_orm(o[0]) for o in scripts}.values())

--- a/MODAK/MODAK/mapper.py
+++ b/MODAK/MODAK/mapper.py
@@ -137,7 +137,7 @@ class Mapper:
             image_hub = data[0][2]
 
             # replace the image hub with the alias if available
-            image_hub = Settings.IMAGE_HUB_ALIASES.get(image_hub, image_hub)
+            image_hub = Settings.image_hub_aliases.get(image_hub, image_hub)
 
             container_link = f"{image_hub}://{container_file}"
             logging.info(f"Container link: {container_link}")

--- a/MODAK/MODAK/mapper.py
+++ b/MODAK/MODAK/mapper.py
@@ -176,6 +176,8 @@ class Mapper:
         return None
 
     def decode_hpc_opt(self, opt: Optimisation) -> Optional[str]:
+        """Get a DSL code for the given optimisation values for the HPC app_type"""
+
         logging.info("Decoding HPC optimisation")
 
         assert opt.app_type == "hpc"
@@ -219,6 +221,8 @@ class Mapper:
         return None
 
     def decode_ai_training_opt(self, opt: Optimisation) -> Optional[str]:
+        """Get a DSL code for the given optimisation values for the ai_training app_type"""
+
         logging.info("Decoding AI training optimisation")
 
         assert opt.app_type == "ai_training"
@@ -259,11 +263,21 @@ class Mapper:
         return dsl_code
 
     def get_opts(self):
+        """
+        Get the list of opts ("k:v" with k:v from either config.parallelisation
+        or ai_framework-*) after decoding from a request via decode_*
+        """
+
         return self._opts
 
     def get_decoded_opts(
         self, opt: Optional[Optimisation] = None, target: Optional[Target] = None
     ):
+        """
+        Get a list of strings from the respectives optimisation type config.*
+        section of keys&values. Also includes target.name:true if the target is
+        specified.
+        """
         opts = []
 
         if target:

--- a/MODAK/MODAK/mapper.py
+++ b/MODAK/MODAK/mapper.py
@@ -159,11 +159,11 @@ class Mapper:
             "SELECT container_file, image_type, image_hub FROM mapper"
             " WHERE opt_dsl_code=%s ORDER BY map_id desc limit 1"
         )
-        df = self._driver.applySQL(stmt, (opt_dsl_code,))
+        data = self._driver.selectSQL(stmt, (opt_dsl_code,))
 
-        if df.size > 0:
-            container_file = df["container_file"][0]
-            image_hub = df["image_hub"][0]
+        if data:
+            container_file = data[0][0]
+            image_hub = data[0][2]
 
             # replace the image hub with the alias if available
             image_hub = Settings.IMAGE_HUB_ALIASES.get(image_hub, image_hub)
@@ -209,16 +209,16 @@ class Mapper:
         else:
             sqlstr += " AND target LIKE '%enable_opt_build:false%'"
 
-        df = self._driver.selectSQL(sqlstr, {"app_name": optimisations.library})
-        if df.size > 0:
-            dsl_code = df["opt_dsl_code"][0]
+        data = self._driver.selectSQL(sqlstr, {"app_name": optimisations.library})
+        if data:
+            dsl_code = data[0][0]
             logging.info(f"Decoded DSL code: {dsl_code}")
             return dsl_code
 
         logging.warning("Failed to find a matching DSL code")
         return None
 
-    def decode_ai_training_opt(self, opt: Optimisation):
+    def decode_ai_training_opt(self, opt: Optimisation) -> Optional[str]:
         logging.info("Decoding AI training optimisation")
 
         assert opt.app_type == "ai_training"
@@ -249,11 +249,12 @@ class Mapper:
         else:
             sqlstr += " AND target LIKE '%enable_opt_build:false%'"
 
-        df = self._driver.selectSQL(sqlstr, {"app_name": app_name})
-        if df.size > 0:
-            dsl_code = df["opt_dsl_code"][0]
+        data = self._driver.selectSQL(sqlstr, {"app_name": app_name})
+        if data:
+            dsl_code = data[0][0]
         else:
             dsl_code = None
+
         logging.info(f"Decoded dsl code '{dsl_code}'")
         return dsl_code
 

--- a/MODAK/MODAK/model.py
+++ b/MODAK/MODAK/model.py
@@ -99,7 +99,12 @@ class Application(BaseModel):
     app_type: Optional[ApplicationAppTypeEnum]
     executable: str
     arguments: Optional[str]
-    container_runtime: Optional[str]
+    container_runtime: Optional[str] = Field(
+        description=(
+            "Will be filled/overwritten in the response"
+            " if an optimised container was found."
+        )
+    )
     mpi_ranks: PositiveInt = Field(
         1,  # default
         description=(
@@ -291,9 +296,15 @@ class Job(BaseModel, extra=Extra.forbid):
     target: Optional[Target]
     application: Application
     optimisation: Optional[Optimisation]
-    job_script: Optional[str]  # the generated job_script
-    build_script: Optional[str]  # the generated build_script
-    job_content: Optional[str]  # the content of the generated job_script
+    job_script: Optional[str] = Field(
+        description="A link to the job script generated for the request"
+    )
+    build_script: Optional[str] = Field(
+        description="The content of the build script generated for the request"
+    )
+    job_content: Optional[str] = Field(
+        description="The content of the job script generated for the request"
+    )
 
 
 class JobModel(BaseModel):

--- a/MODAK/MODAK/model.py
+++ b/MODAK/MODAK/model.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from enum import Enum
 from typing import Any, Dict, Optional
+from uuid import UUID
 
 from pydantic import (
     AnyUrl,
@@ -357,3 +358,36 @@ class JobModel(BaseModel):
     class Config:
         title = "MODAK Job schema"
         extra = "forbid"
+
+
+class ScriptConditions(BaseModel):
+    pass
+
+
+class ScriptData(BaseModel):
+    pass
+
+
+class Script(BaseModel):
+    id: UUID
+    description: str
+    conditions: ScriptConditions
+    data: ScriptData
+
+    class Config:
+        orm_mode = True
+
+
+class ScriptIn(BaseModel):
+    description: str
+    conditions: ScriptConditions
+    data: ScriptData
+
+
+class ScriptList(BaseModel):
+    id: UUID
+    description: str
+    conditions: ScriptConditions
+
+    class Config:
+        orm_mode = True

--- a/MODAK/MODAK/modeldb.py
+++ b/MODAK/MODAK/modeldb.py
@@ -1,0 +1,35 @@
+"""Routines to create DB objects from Schema instances"""
+
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import db, model
+
+
+class ConstraintFailureError(Exception):
+    pass
+
+
+async def create_script(session: AsyncSession, script_in: model.ScriptIn) -> db.Script:
+    try:
+        infrastructure_name = cast(
+            model.ScriptConditionApplication, script_in.conditions.infrastructure
+        ).name
+
+        result = await session.execute(
+            select(db.Infrastructure).where(
+                db.Infrastructure.name == infrastructure_name
+            )
+        )
+        result.one()  # will raise if not found
+    except AttributeError:
+        pass
+    except NoResultFound:
+        raise ConstraintFailureError(
+            f"Infrastructure named '{infrastructure_name}' not found"
+        ) from None
+
+    return db.Script(**script_in.dict())

--- a/MODAK/MODAK/scripts/enable_xla.sh
+++ b/MODAK/MODAK/scripts/enable_xla.sh
@@ -1,3 +1,0 @@
-mkdir xla_dump
-export TF_XLA_FLAGS="--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit"
-export XLA_FLAGS="--xla_dump_to=xla_dump/generated"

--- a/MODAK/MODAK/scripts/enable_xla.sh
+++ b/MODAK/MODAK/scripts/enable_xla.sh
@@ -1,6 +1,3 @@
-## MODAK: START OF OPT:XLA ##
 mkdir xla_dump
 export TF_XLA_FLAGS="--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit"
 export XLA_FLAGS="--xla_dump_to=xla_dump/generated"
-## MODAK: END OF OPT:XLA ##
-

--- a/MODAK/MODAK/scripts/set_default_cirrus.sh
+++ b/MODAK/MODAK/scripts/set_default_cirrus.sh
@@ -1,6 +1,0 @@
-## MODAK: START CIRRUS  ##
-module load mpt
-module load intel-compilers-18
-module load singularity
-## MODAK: END CIRRUS ##
-

--- a/MODAK/MODAK/scripts/set_default_daint.sh
+++ b/MODAK/MODAK/scripts/set_default_daint.sh
@@ -1,5 +1,0 @@
-## MODAK: START DAINT  ##
-module swap PrgEnv-cray PrgEnv-gnu
-module load singularity
-## MODAK: END DAINT ##
-

--- a/MODAK/MODAK/scripts/set_default_egi.sh
+++ b/MODAK/MODAK/scripts/set_default_egi.sh
@@ -1,4 +1,0 @@
-## MODAK: START HLRS TESTBED ##
-module load mpi/openmpi-x86_64
-## MODAK: END HLRS TESTBED ##
-

--- a/MODAK/MODAK/scripts/set_default_hlrs_testbed.sh
+++ b/MODAK/MODAK/scripts/set_default_hlrs_testbed.sh
@@ -1,4 +1,0 @@
-## MODAK: START HLRS TESTBED ##
-export PATH=/usr/local/bin:$PATH
-## MODAK: END HLRS TESTBED ##
-

--- a/MODAK/MODAK/settings.py
+++ b/MODAK/MODAK/settings.py
@@ -23,14 +23,14 @@ def configparser_settings_source(settings: BaseSettings) -> Dict[str, Any]:
         config.read(conf_file)
 
         data: Dict[str, Any] = {
-            "mode": config.get("modak", "mode"),
+            "mode": config["modak"]["mode"],
         }
 
-        data["quiet_server_logs"] = config.get("modak", "quiet_server_log") == "true"
+        data["quiet_server_logs"] = config["modak"]["quiet_server_log"] == "true"
 
-        section = data["mode"]
-        logging.info(f"Reading section {section} of ini file ")
-        data["db_uri"] = config.get(section, "db_uri")
+        section = config[data["mode"]]
+        logging.info(f"Reading section {data['mode']} of ini file ")
+        data["db_uri"] = section["db_uri"]
 
         match = re.match(
             r"(?P<dialect>mysql|sqlite)://"
@@ -58,8 +58,14 @@ def configparser_settings_source(settings: BaseSettings) -> Dict[str, Any]:
         else:
             raise AssertionError(f"Invalid dialect: {match['dialect']}")
 
-        data["out_dir"] = pathlib.Path(config.get(section, "out_dir"))
+        data["out_dir"] = pathlib.Path(section["out_dir"])
         logging.info("out dir : {data['out_dir']}")
+
+        if "google_credentials" in section:
+            data["google_credentials"] = section["google_credentials"]
+
+        if "dropbox_access_token" in section:
+            data["dropbox_access_token"] = section["dropbox_access_token"]
 
         sa_section = f"{data['mode']}.image_hub_aliases"
         data["image_hub_aliases"] = (
@@ -88,6 +94,9 @@ class SettingsBase(BaseSettings):
     db_path: Optional[pathlib.Path]
     out_dir: pathlib.Path
     image_hub_aliases: Dict[str, str]
+
+    google_credentials: Optional[pathlib.Path]
+    dropbox_access_token: Optional[str]
 
     class Config:
         env_file_encoding = "utf-8"

--- a/MODAK/MODAK/settings.py
+++ b/MODAK/MODAK/settings.py
@@ -4,72 +4,107 @@ import os
 import pathlib
 import re
 from configparser import ConfigParser
-from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+from pydantic import BaseSettings
 
 DEFAULT_SETTINGS_DIR = pathlib.Path(__file__).parent.resolve().parent / "conf"
 
 
-class SettingsNamespace(SimpleNamespace):
+def configparser_settings_source(settings: BaseSettings) -> Dict[str, Any]:
+    conf_file = pathlib.Path(
+        os.environ.get("MODAK_CONFIG", DEFAULT_SETTINGS_DIR / "iac-model.ini")
+    )
+
+    logging.info(f"Reading ini file : {conf_file}")
+
+    try:
+        config = ConfigParser()
+        config.read(conf_file)
+
+        data: Dict[str, Any] = {
+            "mode": config.get("modak", "mode"),
+        }
+
+        data["quiet_server_logs"] = config.get("modak", "quiet_server_log") == "true"
+
+        section = data["mode"]
+        logging.info(f"Reading section {section} of ini file ")
+        data["db_uri"] = config.get(section, "db_uri")
+
+        match = re.match(
+            r"(?P<dialect>mysql|sqlite)://"
+            r"(?P<path>(?:(?P<username>[^@:]+)(?::(?P<password>[^@]+))?@)?"
+            r"(?P<hostname>[^@/:]+)?(?::(?P<port>\d+))?/"
+            r"(?P<dbname>.+))",
+            data["db_uri"],
+        )
+
+        if not match:
+            raise ValueError(f"Unable to parse db_uri '{data['db_uri']}'")
+
+        data["db_dialect"] = match["dialect"]
+
+        if data["db_dialect"] == "mysql":
+            data["db_user"] = match["username"]
+            data["db_password"] = match["password"] if match["password"] else ""
+            data["db_host"] = match["host"]
+            data["db_port"] = int(match["port"]) if match["port"] else 3306
+            data["db_name"] = match["dbname"]
+        elif data["db_dialect"] == "sqlite":
+            # relative directories are taken as relative to the configuration file,
+            # absolute dirs are maintained as such
+            data["db_path"] = conf_file.parent / match["path"]
+        else:
+            raise AssertionError(f"Invalid dialect: {match['dialect']}")
+
+        data["out_dir"] = pathlib.Path(config.get(section, "out_dir"))
+        logging.info("out dir : {data['out_dir']}")
+
+        sa_section = f"{data['mode']}.image_hub_aliases"
+        data["image_hub_aliases"] = (
+            dict(config.items(sa_section)) if config.has_section(sa_section) else {}
+        )
+
+    except configparser.Error as exc:
+        logging.exception(exc)
+        raise
+
+    return data
+
+
+class SettingsBase(BaseSettings):
     """All settings required for MODAK will be stored in an instance of this."""
 
-    def initialise(
-        self, conf_file: pathlib.Path = DEFAULT_SETTINGS_DIR / "iac-model.ini"
-    ):
-        my_conf_file = os.environ.get("MODAK_CONFIG", conf_file)
-        db_uri = os.environ.get("MODAK_DATABASE_URI")
+    mode: str
+    quiet_server_logs: bool
+    db_uri: str
+    db_dialect: str
+    db_user: Optional[str]
+    db_password: Optional[str]
+    db_host: Optional[str]
+    db_port: Optional[int]
+    db_name: Optional[str]
+    db_path: Optional[pathlib.Path]
+    out_dir: pathlib.Path
+    image_hub_aliases: Dict[str, str]
 
-        logging.info(f"Reading ini file : {my_conf_file}")
-        try:
-            config = ConfigParser()
-            config.read(my_conf_file)
-            self.MODE = config.get("modak", "mode")
-            self.QUIET_SERVER_LOGS = False
-            if config.get("modak", "quiet_server_log") == "true":
-                self.QUIET_SERVER_LOGS = True
-            self.PRODUCTION = self.MODE == "prod"
+    class Config:
+        env_file_encoding = "utf-8"
 
-            section = self.MODE
-            logging.info(f"Reading section {section} of ini file ")
-            self.DB_URI = db_uri if db_uri else config.get(section, "db_uri")
-
-            match = re.match(
-                r"(?P<dialect>mysql|sqlite)://"
-                r"(?P<path>(?:(?P<username>[^@:]+)(?::(?P<password>[^@]+))?@)?"
-                r"(?P<hostname>[^@/:]+)?(?::(?P<port>\d+))?/"
-                r"(?P<dbname>.+))",
-                Settings.DB_URI,
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings,
+            env_settings,
+            file_secret_settings,
+        ):
+            return (
+                init_settings,
+                configparser_settings_source,
+                env_settings,
+                file_secret_settings,
             )
 
-            if not match:
-                raise ValueError(f"Unable to parse db_uri '{Settings.DB_URI}'")
 
-            self.DB_DIALECT = match["dialect"]
-
-            if self.DB_DIALECT == "mysql":
-                self.DB_USER = match["username"]
-                self.DB_PASSWORD = match["password"] if match["password"] else ""
-                self.DB_HOST = match["host"]
-                self.DB_PORT = int(match["port"]) if match["port"] else 3306
-                self.DB_NAME = match["dbname"]
-            elif self.DB_DIALECT == "sqlite":
-                # relative directories are taken as relative to the configuration file,
-                # absolute dirs are maintained as such
-                self.DB_PATH = conf_file.parent / match["path"]
-            else:
-                raise AssertionError(f"Invalid dialect: {match['dialect']}")
-
-            self.OUT_DIR = pathlib.Path(config.get(section, "out_dir"))
-            logging.info("out dir : {self.OUT_DIR}")
-
-            self.IMAGE_HUB_ALIASES = {}
-            sa_section = f"{self.MODE}.image_hub_aliases"
-            if config.has_section(sa_section):
-                self.IMAGE_HUB_ALIASES = dict(config.items(sa_section))
-
-        except configparser.Error as exc:
-            logging.exception(exc)
-            raise
-
-
-# The default settings
-Settings = SettingsNamespace()
+Settings = SettingsBase()

--- a/MODAK/db/modak_prod.sql
+++ b/MODAK/db/modak_prod.sql
@@ -60,8 +60,3 @@ INSERT INTO `mapper` VALUES
   (38,'mpich_ub1804_cuda101_mpi314_gnugprof','ethcscs/mpich:ub1804_cuda101_mpi314_gnugprof','docker','docker','none'),
   (39,'mvapich_ub1804_cuda101_mpi22_osu','ethcscs/mvapich:ub1804_cuda101_mpi22_osu','docker','docker','none'),
   (48,'pottava_openmpi:1.10','pottava/openmpi:1.10','docker','docker','none');
-
-INSERT INTO `optscript` VALUES
-  ('egi','set_default_egi.sh','file://modak-builtin/set_default_egi.sh',0),
-  ('hlrs_testbed','set_default_hlrs_testbed.sh','file://modak-builtin/set_default_hlrs_testbed.sh',0),
-  ('xla','enable_xla.sh','file://modak-builtin/enable_xla.sh',0);

--- a/MODAK/db/modak_prod.sql
+++ b/MODAK/db/modak_prod.sql
@@ -1,15 +1,3 @@
-BEGIN EXCLUSIVE TRANSACTION;
-
-DROP TABLE IF EXISTS `optimisation`;
-CREATE TABLE `optimisation` (
-	`opt_dsl_code` varchar(255) NOT NULL,
-	`app_name` varchar(255) DEFAULT NULL,
-	`target` varchar(5000) DEFAULT NULL,
-	`optimisation` varchar(5000) DEFAULT NULL,
-	`version` varchar(255) DEFAULT NULL,
-	PRIMARY KEY (`opt_dsl_code`)
-) WITHOUT ROWID;
-
 INSERT INTO `optimisation` VALUES
   ('ethcscs_openmpi_3.1.3','openmpi','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.3,mpicc:true,mpic++:true,mpifort:true,','3.1.3'),
   ('modak-pytorch-1.5-cpu-pip','pytorch','enable_opt_build:true|cpu_type:none|acc_type:none|','version:1.5|',NULL),
@@ -42,18 +30,6 @@ INSERT INTO `optimisation` VALUES
   ('TF_PIP_XLA','tensorflow','cpu_type:x86,acc_type:nvidia,','xla:true,version:1.1,','');
 
 
-DROP TABLE IF EXISTS `mapper`;
-CREATE TABLE `mapper` (
-	`map_id` int,
-	`opt_dsl_code` varchar(255) NOT NULL,
-	`container_file` varchar(255) DEFAULT NULL,
-	`image_type` varchar(255) DEFAULT NULL,
-	`image_hub` varchar(255) DEFAULT NULL,
-	`src` varchar(255) DEFAULT NULL,
-	PRIMARY KEY (`map_id`),
-	CONSTRAINT `opt_dsl_code` FOREIGN KEY (`opt_dsl_code`) REFERENCES `optimisation` (`opt_dsl_code`)
-);
-
 INSERT INTO `mapper` VALUES
   (1,'modak-pytorch-1.5-cpu-pip','modakopt/modak:pytorch-1.5-cpu-pip','docker','docker','none'),
   (2,'modak-pytorch-1.5-cpu-src','modakopt/modak:pytorch-1.5-cpu-src','docker','docker','none'),
@@ -85,19 +61,7 @@ INSERT INTO `mapper` VALUES
   (39,'mvapich_ub1804_cuda101_mpi22_osu','ethcscs/mvapich:ub1804_cuda101_mpi22_osu','docker','docker','none'),
   (48,'pottava_openmpi:1.10','pottava/openmpi:1.10','docker','docker','none');
 
-DROP TABLE IF EXISTS `optscript`;
-CREATE TABLE `optscript` (
-	`opt_code` varchar(255) NOT NULL,
-	`script_name` varchar(255) DEFAULT NULL,
-	`script_loc` varchar(5000) DEFAULT NULL,
-	`stage` int DEFAULT NULL,
-	PRIMARY KEY (`opt_code`)
-) WITHOUT ROWID;
-
 INSERT INTO `optscript` VALUES
   ('egi','set_default_egi.sh','file://modak-builtin/set_default_egi.sh',0),
   ('hlrs_testbed','set_default_hlrs_testbed.sh','file://modak-builtin/set_default_hlrs_testbed.sh',0),
   ('xla','enable_xla.sh','file://modak-builtin/enable_xla.sh',0);
-
-
-COMMIT;

--- a/MODAK/db/modak_test.sql
+++ b/MODAK/db/modak_test.sql
@@ -4,7 +4,8 @@ INSERT INTO `optimisation` VALUES
   ('code-aster-14.4-mpich-avx2','mpich','enable_opt_build:true|cpu_type:x86|acc_type:none|','version:3.3.1|','3.3.1'),
   ('modak-tensorflow-2.2.1-gpu-py3','tensorflow','enable_opt_build:true|cpu_type:x86|acc_type:nvidia|','xla:true|version:2.2.1|','2.2.1'),
   ('ethcscs_openmpi_3.1.3','openmpi','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.3,mpicc:true,mpic++:true,mpifort:true,','3.1.3'),
-  ('mpich_ub1804_cuda101_mpi314_gnugprof','mpich','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.4,mpic++:true,mpicc:true,','3.1.4');
+  ('mpich_ub1804_cuda101_mpi314_gnugprof','mpich','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.4,mpic++:true,mpicc:true,','3.1.4'),
+  ('TF_PIP_XLA','tensorflow','cpu_type:x86,acc_type:nvidia,','xla:true,version:1.1,','');
 
 INSERT INTO `mapper` VALUES
   (11,'modak-tensorflow-2.1-gpu-src','modakopt/modak:tensorflow-2.1-gpu-src','docker','docker','none'),
@@ -13,7 +14,9 @@ INSERT INTO `mapper` VALUES
   (33,'ethcscs_openmpi_3.1.3','ethcscs/openmpi:3.1.3','docker','docker',''),
   (38,'mpich_ub1804_cuda101_mpi314_gnugprof','ethcscs/mpich:ub1804_cuda101_mpi314_gnugprof','docker','docker','none');
 
-INSERT INTO `optscript` VALUES
-  ('egi','set_default_egi.sh','file://modak-builtin/set_default_egi.sh',0),
-  ('hlrs_testbed','set_default_hlrs_testbed.sh','file://modak-builtin/set_default_hlrs_testbed.sh',0),
-  ('xla','enable_xla.sh','file://modak-builtin/enable_xla.sh',0);
+INSERT INTO infrastructure VALUES
+  ('504f14b523a3405c911f50c8a9c31c0d', 'egi', NULL, 'HLRS Testbed', '{}');
+
+INSERT INTO script VALUES
+  ('80593ce7fc404e1d988d84c38930f8e5', NULL, '{"application": {"name": "openmpi", "feature": {}}, "infrastructure": {"name": "egi"}}', '{"stage": "pre", "raw": "module load mpi/openmpi-x86_64"}'),
+  ('16c9b7309a2d4d80b4c9a045ab885984', NULL, '{"application": {"name": "tensorflow", "feature": {"xla": true}}, "infrastructure": null}','{"stage": "pre", "raw": "mkdir xla_dump\nexport TF_XLA_FLAGS=\"--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit\"\nexport XLA_FLAGS=\"--xla_dump_to=xla_dump/generated\""}');

--- a/MODAK/db/modak_test.sql
+++ b/MODAK/db/modak_test.sql
@@ -1,52 +1,19 @@
-BEGIN EXCLUSIVE TRANSACTION;
-
-DROP TABLE IF EXISTS `optimisation`;
-CREATE TABLE `optimisation` (
-	`opt_dsl_code` varchar(255) NOT NULL,
-	`app_name` varchar(255) DEFAULT NULL,
-	`target` varchar(5000) DEFAULT NULL,
-	`optimisation` varchar(5000) DEFAULT NULL,
-	`version` varchar(255) DEFAULT NULL,
-	PRIMARY KEY (`opt_dsl_code`)
-) WITHOUT ROWID;
-
-
 INSERT INTO `optimisation` VALUES
   ('pytorch-latest','pytorch','enable_opt_build:false|cpu_type:x86|acc_type:nvidia|','version:latest|','latest'),
   ('modak-tensorflow-2.1-gpu-src','tensorflow','enable_opt_build:true|cpu_type:x86|acc_type:nvidia|','xla:true|version:2.1|','2.1'),
+  ('code-aster-14.4-mpich-avx2','mpich','enable_opt_build:true|cpu_type:x86|acc_type:none|','version:3.3.1|','3.3.1'),
+  ('modak-tensorflow-2.2.1-gpu-py3','tensorflow','enable_opt_build:true|cpu_type:x86|acc_type:nvidia|','xla:true|version:2.2.1|','2.2.1'),
   ('ethcscs_openmpi_3.1.3','openmpi','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.3,mpicc:true,mpic++:true,mpifort:true,','3.1.3'),
   ('mpich_ub1804_cuda101_mpi314_gnugprof','mpich','enable_opt_build:true,cpu_type:x86,acc_type:nvidia,','version:3.1.4,mpic++:true,mpicc:true,','3.1.4');
 
-DROP TABLE IF EXISTS `mapper`;
-CREATE TABLE `mapper` (
-	`map_id` int,
-	`opt_dsl_code` varchar(255) NOT NULL,
-	`container_file` varchar(255) DEFAULT NULL,
-	`image_type` varchar(255) DEFAULT NULL,
-	`image_hub` varchar(255) DEFAULT NULL,
-	`src` varchar(255) DEFAULT NULL,
-	PRIMARY KEY (`map_id`),
-	CONSTRAINT `opt_dsl_code` FOREIGN KEY (`opt_dsl_code`) REFERENCES `optimisation` (`opt_dsl_code`) ON DELETE CASCADE ON UPDATE CASCADE
-);
-
 INSERT INTO `mapper` VALUES
   (11,'modak-tensorflow-2.1-gpu-src','modakopt/modak:tensorflow-2.1-gpu-src','docker','docker','none'),
+  (12,'modak-tensorflow-2.2.1-gpu-py3','tensorflow_2.2.1-gpu-py3','shub','library','none'),
+  (13,'code-aster-14.4-mpich-avx2','code_aster_14.4.0_mpich_avx2','shub','library','none'),
   (33,'ethcscs_openmpi_3.1.3','ethcscs/openmpi:3.1.3','docker','docker',''),
   (38,'mpich_ub1804_cuda101_mpi314_gnugprof','ethcscs/mpich:ub1804_cuda101_mpi314_gnugprof','docker','docker','none');
-
-
-DROP TABLE IF EXISTS `optscript`;
-CREATE TABLE `optscript` (
-	`opt_code` varchar(255) NOT NULL,
-	`script_name` varchar(255) DEFAULT NULL,
-	`script_loc` varchar(5000) DEFAULT NULL,
-	`stage` int DEFAULT NULL,
-	PRIMARY KEY (`opt_code`)
-) WITHOUT ROWID;
 
 INSERT INTO `optscript` VALUES
   ('egi','set_default_egi.sh','file://modak-builtin/set_default_egi.sh',0),
   ('hlrs_testbed','set_default_hlrs_testbed.sh','file://modak-builtin/set_default_hlrs_testbed.sh',0),
   ('xla','enable_xla.sh','file://modak-builtin/enable_xla.sh',0);
-
-COMMIT;

--- a/MODAK/db/tosqlite.py
+++ b/MODAK/db/tosqlite.py
@@ -2,30 +2,33 @@
 
 import argparse
 import pathlib
-import sqlite3
 import sys
+
+import sqlalchemy
+
+from MODAK.db import Base
 
 SCRIPT_DIR = pathlib.Path(__file__).parent.resolve()
 
-prod_sql_path = SCRIPT_DIR / "modak_prod.sql"
-test_sql_path = SCRIPT_DIR / "modak_test.sql"
 
+def create(db_path, sql_path):
+    if db_path.exists():
+        db_path.unlink()
 
-def create(out_dir, force=False):
-    prod_db_path = out_dir / "iac_model.db"
-    test_db_path = out_dir / "test_iac_model.db"
+    engine = sqlalchemy.create_engine(f"sqlite:///{db_path}")
 
-    if (prod_db_path.exists() or test_db_path.exists()) and not force:
-        print("ERROR: target database files already exist")
-        sys.exit(1)
+    print(f"INFO: Creating schema on '{db_path}'...")
+    Base.metadata.create_all(engine)
 
-    with sqlite3.connect(prod_db_path) as con:
-        print(f"INFO: Loading '{prod_sql_path.name}' into '{prod_db_path}'")
-        con.executescript(prod_sql_path.read_text())
-
-    with sqlite3.connect(test_db_path) as con:
-        print(f"INFO: Loading '{test_sql_path.name}' into '{test_db_path}'")
-        con.executescript(test_sql_path.read_text())
+    print(f"INFO: Loading '{sql_path.name}' into '{db_path}'")
+    con = engine.raw_connection()
+    # Load the data via raw connection here to avoid var substitution:
+    #   :true gets interpreted as var when loaded via SQLA's text()
+    try:
+        con.executescript(sql_path.read_text())
+        con.commit()
+    finally:
+        con.close()
 
 
 if __name__ == "__main__":
@@ -47,4 +50,13 @@ if __name__ == "__main__":
         help="overwrite existing DB files",
     )
     args = parser.parse_args()
-    create(args.directory, args.force)
+
+    prod_db_path = args.directory / "iac_model.db"
+    test_db_path = args.directory / "test_iac_model.db"
+
+    if (prod_db_path.exists() or test_db_path.exists()) and not args.force:
+        print("ERROR: target database files already exist")
+        sys.exit(1)
+
+    create(prod_db_path, SCRIPT_DIR / "modak_prod.sql")
+    create(test_db_path, SCRIPT_DIR / "modak_test.sql")

--- a/MODAK/pyproject.toml
+++ b/MODAK/pyproject.toml
@@ -6,4 +6,4 @@ profile = 'black'
 
 [tool.mypy]
 ignore_missing_imports = true
-plugins = 'pydantic.mypy'
+plugins = ['pydantic.mypy', 'sqlalchemy.ext.mypy.plugin']

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -5,5 +5,5 @@ sqlalchemy[asyncio,aiosqlite]==1.4.25
 rich==10.12.0
 pytest==6.2.4
 pytest-cov==2.12.1
-
+requests==2.26.0
 uvicorn==0.15.0

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -2,6 +2,7 @@ Jinja2==3.0.1
 pydantic[email]==1.8.2
 fastapi==0.68.2
 sqlalchemy[asyncio,aiosqlite]==1.4.25
+rich==10.12.0
 pytest==6.2.4
 pytest-cov==2.12.1
 

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==3.0.1
 pydantic[email]==1.8.2
 fastapi==0.68.2
-
+sqlalchemy==1.4.25
 pytest==6.2.4
 pytest-cov==2.12.1
 

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -1,7 +1,7 @@
 Jinja2==3.0.1
 pydantic[email]==1.8.2
 fastapi==0.68.2
-sqlalchemy==1.4.25
+sqlalchemy[asyncio,aiosqlite]==1.4.25
 pytest==6.2.4
 pytest-cov==2.12.1
 

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -5,5 +5,6 @@ sqlalchemy[asyncio,aiosqlite]==1.4.25
 rich==10.12.0
 pytest==6.2.4
 pytest-cov==2.12.1
+pytest-console-scripts==1.2.1
 requests==2.26.0
 uvicorn==0.15.0

--- a/MODAK/requirements.txt
+++ b/MODAK/requirements.txt
@@ -1,5 +1,3 @@
-numpy==1.21.1
-pandas==1.3.1
 Jinja2==3.0.1
 pydantic[email]==1.8.2
 fastapi==0.68.2

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -29,6 +29,7 @@ setup(
             "modak-validate-json = MODAK.cli:validate_json",
             "modak-schema = MODAK.cli:schema",
             "modak-import-script = MODAK.cli:import_script",
+            "modak-dbshell = MODAK.cli:dbshell",
         ],
     },
 )

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -18,7 +18,7 @@ setup(
         "console_scripts": [
             "modak = MODAK.cli:validate_json",
             "modak-validate-json = MODAK.cli:validate_json",
-            "modak-openapi = MODAK.cli:openapi",
+            "modak-schema = MODAK.cli:schema",
         ],
     },
 )

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -10,13 +10,21 @@ setup(
         "Jinja2",
         "fastapi",
         "uvicorn",
+        "sqlalchemy",
     ],
     extras_require={
         "testing": ["pytest", "pytest-cov"],
+        "docs": [
+            "sphinx",
+            "autodoc_pydantic",
+            "sphinx-rtd-theme",
+            "myst_parser",
+            "autoapi",
+        ],
     },
     entry_points={
         "console_scripts": [
-            "modak = MODAK.cli:validate_json",
+            "modak = MODAK.cli:modak",
             "modak-validate-json = MODAK.cli:validate_json",
             "modak-schema = MODAK.cli:schema",
         ],

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -10,10 +10,10 @@ setup(
         "Jinja2",
         "fastapi",
         "uvicorn",
-        "sqlalchemy",
+        "sqlalchemy[asyncio,aiosqlite]",
     ],
     extras_require={
-        "testing": ["pytest", "pytest-cov"],
+        "testing": ["pytest", "pytest-cov", "sqlalchemy[mypy]"],
         "docs": [
             "sphinx",
             "autodoc_pydantic",

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -7,8 +7,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "pydantic[email]",
-        "numpy",
-        "pandas",
         "Jinja2",
         "fastapi",
         "uvicorn",
@@ -18,7 +16,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "modak = MODAK.cli:modak",
+            "modak = MODAK.cli:validate_json",
             "modak-validate-json = MODAK.cli:validate_json",
             "modak-openapi = MODAK.cli:openapi",
         ],

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -15,7 +15,12 @@ setup(
         "requests",
     ],
     extras_require={
-        "testing": ["pytest", "pytest-cov", "sqlalchemy[mypy]"],
+        "testing": [
+            "pytest",
+            "pytest-cov",
+            "sqlalchemy[mypy]",
+            "pytest-console-scripts",
+        ],
         "docs": [
             "sphinx",
             "autodoc_pydantic",

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -11,6 +11,7 @@ setup(
         "fastapi",
         "uvicorn",
         "sqlalchemy[asyncio,aiosqlite]",
+        "rich",
     ],
     extras_require={
         "testing": ["pytest", "pytest-cov", "sqlalchemy[mypy]"],
@@ -27,6 +28,7 @@ setup(
             "modak = MODAK.cli:modak",
             "modak-validate-json = MODAK.cli:validate_json",
             "modak-schema = MODAK.cli:schema",
+            "modak-import-script = MODAK.cli:import_script",
         ],
     },
 )

--- a/MODAK/setup.py
+++ b/MODAK/setup.py
@@ -12,6 +12,7 @@ setup(
         "uvicorn",
         "sqlalchemy[asyncio,aiosqlite]",
         "rich",
+        "requests",
     ],
     extras_require={
         "testing": ["pytest", "pytest-cov", "sqlalchemy[mypy]"],

--- a/MODAK/test/input/mpi_test_egi.sh
+++ b/MODAK/test/input/mpi_test_egi.sh
@@ -12,10 +12,9 @@
 
 cd "${SLURM_SUBMIT_DIR}"
 export PATH="${SLURM_SUBMIT_DIR}:${PATH}"
-## MODAK: START HLRS TESTBED ##
+# MODAK: Start Script<id=80593ce7-fc40-4e1d-988d-84c38930f8e5>
 module load mpi/openmpi-x86_64
-## MODAK: END HLRS TESTBED ##
-
+# MODAK: End   Script<id=80593ce7-fc40-4e1d-988d-84c38930f8e5>
 
 wget --no-check-certificate https://raw.githubusercontent.com/olcf/XC30-Training/master/affinity/Xthi.c
 

--- a/MODAK/test/input/resnet.sh
+++ b/MODAK/test/input/resnet.sh
@@ -11,10 +11,9 @@
 
 cd "${PBS_O_WORKDIR}"
 export PATH="${PBS_O_WORKDIR}:${PATH}"
-## MODAK: START OF OPT:XLA ##
+# MODAK: Start Script<id=16c9b730-9a2d-4d80-b4c9-a045ab885984>
 mkdir xla_dump
 export TF_XLA_FLAGS="--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit"
 export XLA_FLAGS="--xla_dump_to=xla_dump/generated"
-## MODAK: END OF OPT:XLA ##
-
+# MODAK: End   Script<id=16c9b730-9a2d-4d80-b4c9-a045ab885984>
 singularity exec --nv "$SINGULARITY_DIR/modak_tensorflow-2.1-gpu-src.sif" ./resnet_benchmark.sh

--- a/MODAK/test/test_MODAK_driver.py
+++ b/MODAK/test/test_MODAK_driver.py
@@ -1,5 +1,8 @@
 import unittest
 
+from sqlalchemy import select
+
+from MODAK.db import Optimisation
 from MODAK.MODAK_driver import MODAK_driver
 
 
@@ -12,6 +15,8 @@ class test_MODAK_driver(unittest.TestCase):
 
     def test_driver(self):
         data = self.driver.selectSQL(
-            "SELECT * FROM optimisation WHERE app_name = %s", ("pytorch",)
+            select(Optimisation.opt_dsl_code, Optimisation.app_name).where(
+                Optimisation.app_name == "pytorch"
+            )
         )
         self.assertEqual(data[0][1], "pytorch")

--- a/MODAK/test/test_MODAK_driver.py
+++ b/MODAK/test/test_MODAK_driver.py
@@ -11,11 +11,7 @@ class test_MODAK_driver(unittest.TestCase):
         pass
 
     def test_driver(self):
-        df = self.driver.applySQL(
+        data = self.driver.selectSQL(
             "SELECT * FROM optimisation WHERE app_name = %s", ("pytorch",)
         )
-        self.assertEqual(df["app_name"][0], "pytorch")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(data[0][1], "pytorch")

--- a/MODAK/test/test_api.py
+++ b/MODAK/test/test_api.py
@@ -52,7 +52,7 @@ def test_get_optimise():
 
 def test_create_and_get_script_roundtrip():
     desc = "test"
-    script = ScriptIn(description=desc, conditions={}, data={})
+    script = ScriptIn(description=desc, conditions={}, data={"stage": "pre"})
 
     response = client.post("/scripts", json=script.dict())
     assert response.status_code == 201

--- a/MODAK/test/test_enforcer.py
+++ b/MODAK/test/test_enforcer.py
@@ -1,5 +1,6 @@
 from MODAK.enforcer import Enforcer
 from MODAK.MODAK_driver import MODAK_driver
+from MODAK.model import Target
 
 
 def test_enforce_opt():
@@ -9,9 +10,10 @@ def test_enforce_opt():
 
     driver = MODAK_driver()
     enforcer = Enforcer(driver)
-    opts = enforcer.enforce_opt(["version:2.1", "xla:true"])
+    scripts = enforcer.enforce_opt(
+        "tensorflow",
+        Target(name="test", job_scheduler_type="slurm"),
+        ["version:2.1", "xla:true"],
+    )
 
-    assert opts, "empty set returned"
-    for opt in opts:
-        assert opt.script_name, "script_name empty while it shouldn't be"
-        assert opt.script_loc, "script_loc empty while it shouldn't be"
+    assert scripts, "empty set returned"

--- a/MODAK/test/test_enforcer.py
+++ b/MODAK/test/test_enforcer.py
@@ -9,11 +9,9 @@ def test_enforce_opt():
 
     driver = MODAK_driver()
     enforcer = Enforcer(driver)
-    opts = ["version:2.1", "xla:true"]
-    dfs = enforcer.enforce_opt(opts)
+    opts = enforcer.enforce_opt(["version:2.1", "xla:true"])
 
-    assert dfs, "empty set returned"
-    for df in dfs:
-        for idx in range(0, df.shape[0]):
-            assert df["script_name"][idx], "script_name empty while it shouldn't be"
-            assert df["script_loc"][idx], "script_loc empty while it shouldn't be"
+    assert opts, "empty set returned"
+    for opt in opts:
+        assert opt.script_name, "script_name empty while it shouldn't be"
+        assert opt.script_loc, "script_loc empty while it shouldn't be"

--- a/MODAK/test/test_mapper.py
+++ b/MODAK/test/test_mapper.py
@@ -34,12 +34,12 @@ class test_mapper(unittest.TestCase):
             json.loads(target_string),
             json.loads(opt_string),
         )
-        df = self.driver.applySQL(
+        data = self.driver.selectSQL(
             "SELECT app_name FROM optimisation WHERE opt_dsl_code = %s", ("TF_PIP_XLA",)
         )
-        self.assertEqual(df.size, 1)
-        print(df["app_name"][0])
-        self.assertEqual(df["app_name"][0], "tensorflow")
+        self.assertEqual(len(data), 1)
+        print(data[0][0])
+        self.assertEqual(data[0][0], "tensorflow")
 
     def test_add_container(self):
         self.driver.updateSQL(
@@ -48,13 +48,11 @@ class test_mapper(unittest.TestCase):
         self.m.add_container(
             "TF_PIP_XLA", "AI/containers/tensorflow/tensorflow_pip_xla"
         )
-        df = self.driver.applySQL(
+        data = self.driver.selectSQL(
             "SELECT container_file FROM mapper WHERE opt_dsl_code = %s", ("TF_PIP_XLA",)
         )
-        self.assertEqual(df.size, 1)
-        self.assertEqual(
-            df["container_file"][0], "AI/containers/tensorflow/tensorflow_pip_xla"
-        )
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0][0], "AI/containers/tensorflow/tensorflow_pip_xla")
 
     def test_map_container_ai(self):
         dsl_file = SCRIPT_DIR / "input" / "tf_snow.json"

--- a/MODAK/test/test_mapper.py
+++ b/MODAK/test/test_mapper.py
@@ -48,6 +48,10 @@ class test_mapper(unittest.TestCase):
     def test_add_container(self):
         stmt = delete(Map).where(Map.opt_dsl_code == "TF_PIP_XLA")
         self.driver.updateSQL(stmt)
+        data = self.driver.selectSQL(
+            select(Map.container_file).where(Map.opt_dsl_code == "TF_PIP_XLA")
+        )
+        self.assertEqual(len(data), 0)
         self.m.add_container(
             "TF_PIP_XLA", "AI/containers/tensorflow/tensorflow_pip_xla"
         )
@@ -87,11 +91,3 @@ class test_mapper(unittest.TestCase):
                 new_container,
                 "docker.invalid://modakopt/modak:tensorflow-2.1-gpu-src",
             )
-
-    # def test_add_container(self):
-    #     map_id = self.m.add_container('TF_PIP_XLA',
-    #                                   'AI/containers/tensorflow/tensorflow_pip_xla')
-    #     df = self.driver.applySQL("SELECT opt_dsl_code FROM mapper WHERE map_id = %s",
-    #                               (map_id, ))
-    #     self.assertEqual(df.count(), 1)
-    #     self.assertEqual(df.select('opt_dsl_code').collect()[0][0], 'TF_PIP_XLA')

--- a/MODAK/test/test_mapper.py
+++ b/MODAK/test/test_mapper.py
@@ -78,7 +78,7 @@ class test_mapper(unittest.TestCase):
     def test_map_container_aliased(self):
         dsl_file = SCRIPT_DIR / "input" / "tf_snow.json"
 
-        with patch.object(Settings, "IMAGE_HUB_ALIASES", {"docker": "docker.invalid"}):
+        with patch.object(Settings, "image_hub_aliases", {"docker": "docker.invalid"}):
             model = JobModel.parse_raw(dsl_file.read_text())
             new_container = self.m.map_container(
                 model.job.optimisation, model.job.target

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,11 +2,11 @@
         sonar.projectKey=SODALITE-EU_modak
         sonar.projectName=modak
         sonar.projectVersion=1.0
-        sonar.sources=MODAK/src
+        sonar.sources=MODAK/MODAK
         sonar.language=py
         sonar.sourceEncoding=UTF-8
         # Test Results
-        sonar.python.xunit.reportPath=MODAK/src/results.xml
+        sonar.python.xunit.reportPath=MODAK/MODAK/results.xml
         # Coverage
-        sonar.python.coverage.reportPaths=MODAK/src/coverage.xml
+        sonar.python.coverage.reportPaths=MODAK/MODAK/coverage.xml
         sonar.python.version=3.9


### PR DESCRIPTION
The current non-normalized DB structure makes it rather difficult to issue complex queries reliably and extending it in a flexible way. Going to redo the DB (which is at it turns out not much), likely with async SQLAlchemy (maybe encode/databases). Pandas is mostly used as a wrapper around the cursor, but there's actually no real need for it. Not using it will allow to do `fetchone` instead of `fetchall` where it makes sense.