### PR TITLE
Use images from dockerhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,13 +151,12 @@ pipeline {
                     """
             }
         }
-        stage('Push modak to sodalite-private-registry') {
-            // Push during staging and production
+        stage('Push modak to DockerHub for staging') {
             when {
                 allOf {
                     expression{tag "*"}
                     expression{
-                        TAG_STAGING == 'true' || TAG_PRODUCTION == 'true'
+                        TAG_STAGING == 'true'
                     }
                 }
             }
@@ -166,7 +165,7 @@ pipeline {
                     sh  """#!/bin/bash
                         set -x
                         git status
-                        ./make_docker.sh push modak-api staging
+                        ./make_docker.sh push modak-api sodaliteh2020 staging
                         """
                 }
             }
@@ -184,7 +183,7 @@ pipeline {
             steps {
                 withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
                     sh  """#!/bin/bash
-                            ./make_docker.sh push modak-api production
+                            ./make_docker.sh push modak-api sodaliteh2020 production
                         """
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
        docker_network = "sodalite"
        dockerhub_user = " "
        dockerhub_pass = " "
-       docker_registry_ip = credentials('jenkins-docker-registry-ip')
+       //docker_registry_ip = credentials('jenkins-docker-registry-ip')
        docker_registry_cert_country_name = "SI"
        docker_registry_cert_organization_name = "XLAB"
        docker_public_registry_url = "registry.hub.docker.com"

--- a/deploy-blueprint/input/input-openstack.yaml
+++ b/deploy-blueprint/input/input-openstack.yaml
@@ -11,7 +11,6 @@ docker-network: sodalite
 dockerhub-user:
 dockerhub-pass:
 docker-public-registry-url: registry.hub.docker.com
-docker-private-registry-url: [PRIVATE REGISTRY IP/URL]
 docker-registry-cert-country-name: SI
 docker-registry-cert-organization-name: XLAB
 docker-registry-cert-email-address: [MAIL - OPTIONAL]

--- a/deploy-blueprint/input/input.yaml.tmpl
+++ b/deploy-blueprint/input/input.yaml.tmpl
@@ -14,7 +14,6 @@ docker-network: ${docker_network}
 dockerhub-user: ${dockerhub_user}
 dockerhub-pass: ${dockerhub_pass}
 docker-public-registry-url: ${docker_public_registry_url}
-docker-private-registry-url: ${docker_registry_ip}
 docker-registry-cert-country-name: ${docker_registry_cert_country_name}
 docker-registry-cert-organization-name: ${docker_registry_cert_organization_name}
 docker-registry-cert-email-address: ${docker_registry_cert_email_address}

--- a/deploy-blueprint/service.yaml
+++ b/deploy-blueprint/service.yaml
@@ -39,9 +39,6 @@ topology_template:
     docker-public-registry-url: 
       type: string
       default: ""
-    docker-private-registry-url: 
-      type: string
-      default: ""
     docker-registry-cert-country-name:
       type: string
       default: ""
@@ -129,25 +126,6 @@ topology_template:
         - host: sodalite-vm
         - dependency: docker-host
 
-    docker-private-registry:
-      type: sodalite.nodes.DockerRegistry
-      properties:
-        docker_registry_url: { get_input: docker-private-registry-url }
-      requirements:
-        - host: sodalite-vm
-        - dependency: docker-host
-
-    docker-registry-certificate:
-      type: sodalite.nodes.RegistryCertificate
-      properties:  
-        registry_ip:         { get_input: docker-private-registry-url }
-        country_name:        { get_input: docker-registry-cert-country-name }
-        organization_name:   { get_input: docker-registry-cert-organization-name }
-        email_address:       { get_input: docker-registry-cert-email-address }
-      requirements:
-        - host: sodalite-vm 
-        - dependency: docker-host        
-
     # xopera-rest-api
     # https://github.com/SODALITE-EU/xopera-rest-api        
     openstack-keys:
@@ -214,7 +192,7 @@ topology_template:
       properties:
         alias: modak
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: modak-api:latest
+        image_name: sodaliteh2020/modak-api:latest
         volumes:
           - "/usr/local/modak/iac-model.ini:/usr/local/modak/modak-iac-model.ini"
           - "/usr/local/modak/log:/var/log/modak"
@@ -232,7 +210,7 @@ topology_template:
           traefik.http.routers.api-https.tls: "true"
       requirements:
         - host: docker-host
-        - registry: docker-private-registry
+        - registry: docker-public-registry
         - network: docker-network
         - dependency: openstack-keys
         - dependency: mariadb

--- a/make_docker.sh
+++ b/make_docker.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
+
+# make_docker V2
 #
 # Build or push an image.
-# Images for staging are pushed to sodalite-private-registry on ${docker_registry_ip}
-# Images with production-ready version are pushed to both sodalite-private-registry and dockerhub: sodaliteh2020 repository
 
-# Images from tagged commits are tagged with git tag
-# Images from non-tagged commits are tagged with <last_git_tag>-<commits_since_tag>-<abbreviated_commit_sha>
+# Images from non-tagged commits are versioned by <last_git_tag>-<commits_since_tag>-<abbreviated_commit_sha>
+# Images from tagged commits are versioned by git tag
+
+# Images for staging are tagged and pushed only with ${VERSION}
+# Images for production are tagged and pushed with both tags: latest and ${VERSION}
+
 #
 # Usage:
 #   $0 build <image-name> [Dockerfile-filename]
-#   $0 push <image-name> [production|staging]
+#   $0 push <image-name> <target-registry> [production|staging]
 # image name is pure name without repository (image-name, not sodaliteh2020/image-name)
 
 build() {
@@ -19,42 +23,39 @@ build() {
 }
 
 push() {
-
     set -x
     docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
-    docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:latest"
     docker push "${TARGET_REGISTRY}/${IMAGE}:${VERSION}"
-    docker push "${TARGET_REGISTRY}/${IMAGE}:latest"
     set +x
+
+    if [[ "$TARGET" = 'production' ]]; then
+      set -x
+      docker tag "${IMAGE}":latest "${TARGET_REGISTRY}/${IMAGE}:latest"
+      docker push "${TARGET_REGISTRY}/${IMAGE}:latest"
+      set +x
+    fi
+
 }
 
 
-if [[ $# -gt 3 ]] || [[ $# -lt 2 ]] || \
-   [[ "$1" != "build" && "$1" != "push" ]] || \
-   [[ "$1" = "push" && "$3" != "staging" && "$3" != "production" ]]; then
+if [[ "$1" != "build" && "$1" != "push" ]] || \
+   [[ "$1" = "build" ]] && [[ $# -gt 3 || $# -lt 2 ]] || \
+   [[ "$1" = "push" ]] && [[ $# -gt 4 || $# -lt 3 ]] && [[ "$4" != "staging" && "$4" != "production" ]]; then
 
     echo "Usage: $0 build <image-name> [Dockerfile-filename]"
-    echo "Usage: $0 push <image-name> [production|staging]"
+    echo "Usage: $0 push <image-name> <target-registry> [production|staging]"
     exit 1
 fi
 
-git fetch --tags
-
+git fetch --tags -f
 ACTION=$1
 IMAGE=$2
 if [ "$ACTION" = 'build' ];
   then
     FILE=${3:-Dockerfile}
   else
-    TARGET=${3:-staging}
-fi
-
-if [[ "$ACTION" = 'push' ]]; then
-  if [[ "$TARGET" = 'production' ]]; then
-    TARGET_REGISTRY=sodaliteh2020
-  else
-    TARGET_REGISTRY=${docker_registry_ip:-localhost}
-  fi
+    TARGET_REGISTRY=$3
+    TARGET=${4:-staging}
 fi
 
 VERSION=$(git describe --tag --always | sed -e"s/^v//")
@@ -62,17 +63,27 @@ DATE=$(date -u +%Y-%m-%dT%H:%M:%S)
 
 # debug section
 echo "make_docker.sh:"
+echo
+echo "---------------"
 echo "ACTION: $ACTION"
+if [ "$ACTION" = 'push' ]; then
+  echo "TARGET: $TARGET"
+  echo "TARGET_REGISTRY: $TARGET_REGISTRY"
+fi
 echo "IMAGE: $IMAGE"
-echo "FILE: $FILE"
+if [ "$ACTION" = 'build' ]; then
+  echo "FILE: $FILE"
+fi
 echo "VERSION: $VERSION"
 echo "DATE: $DATE"
-echo "TARGET: $TARGET"
-echo "TARGET_REGISTRY: $TARGET_REGISTRY"
 
+echo "---------------"
+echo
 
 if [ "$ACTION" = "build" ]; then
     build
 else
     push
 fi
+
+echo


### PR DESCRIPTION
Changes:
- make_docker.sh
  - enable manual spec of target registry
- Jenkinsfile
  - Push images to docker hub for both staging and production
- deploy-blueprint
  - use docker.io/sodaliteh2020 instead of sodalite-private-registry as a source for docker images